### PR TITLE
Tmp dcp impl

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -37,6 +37,7 @@ from contextlib import nullcontext
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import numpy as np
+import math
 import torch
 import triton
 import triton.language as tl
@@ -1424,7 +1425,7 @@ class DCPAwareMLATokenToKVPool(MLATokenToKVPool):
         self.dcp_world_size = dcp_world_size
 
         super().__init__(
-            size = ceil(size / dcp_world_size),
+            size = math.ceil(size / dcp_world_size),
             page_size = page_size,
             dtype = dtype,
             kv_lora_rank = kv_lora_rank,
@@ -1439,7 +1440,7 @@ class DCPAwareMLATokenToKVPool(MLATokenToKVPool):
         logger.info(
             f"DCPAwareMLATokenToKVPool initialized: "
             f"dcp_rank={dcp_rank}/{dcp_world_size}, "
-            f"page_size={page_size}, size={ceil(size / dcp_world_size)}."
+            f"page_size={page_size}, size={math.ceil(size / dcp_world_size)}."
         )
 
     def get_physical_loc(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -90,7 +90,6 @@ from sglang.srt.managers.schedule_batch import (
 from sglang.srt.mem_cache.allocator import (
     BaseTokenToKVPoolAllocator,
     PagedTokenToKVPoolAllocator,
-    DCPAwareTokenToKVPoolAllocator,
     SWATokenToKVPoolAllocator,
     TokenToKVPoolAllocator,
 )

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1617,21 +1617,21 @@ class ModelRunner:
                 get_dcp_rank,
                 get_dcp_world_size
             )
-
+            dcp_size = get_dcp_world_size()
             # When DCP is enabled, each rank only stores ~1/dcp_size of tokens physically.
             # Expand logical capacity by dcp_size to utilize freed memory.
-            if self.server_args.dcp_size > 1:
-                expanded = self.max_total_num_tokens * self.server_args.dcp_size
+            if dcp_size > 1:
+                expanded = self.max_total_num_tokens * dcp_size
                 # keep page alignment
                 expanded = expanded // self.server_args.page_size * self.server_args.page_size
                 if expanded != self.max_total_num_tokens:
                     logger.info(
                         f"Expand max_total_num_tokens for DCP: {self.max_total_num_tokens} -> {expanded} "
-                        f"(dcp_size={self.server_args.dcp_size})"
+                        f"(dcp_size={dcp_size})"
                     )
                 self.max_total_num_tokens = expanded
 
-            if self.server_args.dcp_size > 1:
+            if dcp_size > 1:
                 self.token_to_kv_pool = DCPAwareMLATokenToKVPool(
                     self.max_total_num_tokens,
                     page_size=self.page_size,
@@ -1642,7 +1642,7 @@ class ModelRunner:
                     device=self.device,
                     enable_memory_saver=self.server_args.enable_memory_saver,
                     dcp_rank=get_dcp_rank(),
-                    dcp_world_size=get_dcp_world_size(),
+                    dcp_world_size=dcp_size,
                     start_layer=self.start_layer,
                     end_layer=self.end_layer,
                 )

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1140,7 +1140,7 @@ class DeepseekV2AttentionMLA(nn.Module):
             self.rotary_emb.forward = self.rotary_emb.forward_native
         # TODO(augusto.yjh) 这里要改逻辑， local_heads是all heads, 而且还要返回lse，用来修正attn_out
         self.attn_mqa = RadixAttention(
-            self.num_local_heads * get_dcp_world_size(),
+            self.num_local_heads,
             self.kv_lora_rank + self.qk_rope_head_dim,
             self.scaling,
             num_kv_heads=1,

--- a/python/sglang/test/attention/test_dcp_mla_mapping.py
+++ b/python/sglang/test/attention/test_dcp_mla_mapping.py
@@ -1,0 +1,40 @@
+import torch
+
+from sglang.srt.mem_cache.memory_pool import DCPAwareMLATokenToKVPool
+
+
+def test_dcp_mla_get_physical_loc_basic():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    # Small pool just to exercise mapping; we won't allocate KV data
+    pool = DCPAwareMLATokenToKVPool(
+        size=64,
+        page_size=1,
+        dtype=torch.float16,
+        kv_lora_rank=32,
+        qk_rope_head_dim=32,
+        layer_num=1,
+        device=device,
+        enable_memory_saver=False,
+        dcp_rank=1,
+        dcp_world_size=4,
+        start_layer=0,
+        end_layer=0,
+    )
+
+    locs = torch.arange(0, 32, dtype=torch.int32, device=pool.device)
+    phys, mask = pool.get_physical_loc(locs)
+
+    assert mask.dtype == torch.bool
+    assert phys.dtype == torch.int32
+
+    # Only tokens with loc % 4 == 1 belong to rank 1
+    expected_mask = (locs % 4) == 1
+    assert torch.equal(mask, expected_mask)
+
+    # Physical locations are compacted by floor(loc / 4)
+    expected_phys = torch.div(locs, 4, rounding_mode="floor").to(torch.int32)
+    # For tokens not owned, phys is still defined but we only care about owned subset
+    assert torch.equal(phys[mask], expected_phys[mask])
+
+

--- a/python/sglang/test/attention/test_dcp_remap.py
+++ b/python/sglang/test/attention/test_dcp_remap.py
@@ -1,0 +1,81 @@
+import math
+import torch
+
+from sglang.srt.mem_cache.memory_pool import DCPAwareMLATokenToKVPool
+
+
+def apply_dcp_filter_and_remap(kv_indices: torch.Tensor, kv_indptr: torch.Tensor, d: int, r: int):
+    """
+    Replicate the runtime DCP logic:
+      - filter: own = (v % d) == r
+      - remap: phys = floor(v / d)
+      - per-seq lens: count of own tokens in each [kv_indptr[i]:kv_indptr[i+1])
+    """
+    mask = (kv_indices % d) == r
+    kv_indices_remap = torch.div(kv_indices[mask], d, rounding_mode="floor").to(torch.int32)
+
+    bs = kv_indptr.numel() - 1
+    lens = torch.empty((bs,), dtype=torch.int32)
+    for i in range(bs):
+        st = int(kv_indptr[i].item())
+        ed = int(kv_indptr[i + 1].item())
+        lens[i] = int(mask[st:ed].sum().item())
+
+    kv_indptr_remap = torch.empty_like(kv_indptr)
+    kv_indptr_remap[0] = 0
+    kv_indptr_remap[1:] = torch.cumsum(lens, dim=0)
+    return kv_indices_remap, kv_indptr_remap, lens
+
+
+def test_dcp_filter_remap_decode_simple():
+    # kv_indices for 2 sequences: [0,1,2] and [3,4,5]
+    kv_indices = torch.tensor([0, 1, 2, 3, 4, 5], dtype=torch.int32)
+    kv_indptr = torch.tensor([0, 3, 6], dtype=torch.int32)
+    d, r = 2, 1  # keep odd indices
+
+    remap, indptr_remap, lens = apply_dcp_filter_and_remap(kv_indices, kv_indptr, d, r)
+    # expected: keep [1] from first seq -> [0] after floor(1/2)
+    #           keep [3,5] from second seq -> [1,2] after floor(/2)
+    assert torch.equal(remap, torch.tensor([0, 1, 2], dtype=torch.int32))
+    assert torch.equal(lens, torch.tensor([1, 2], dtype=torch.int32))
+    assert torch.equal(indptr_remap, torch.tensor([0, 1, 3], dtype=torch.int32))
+
+
+def test_dcp_order_stable():
+    kv_indices = torch.tensor([2, 3, 5, 8, 11], dtype=torch.int32)
+    kv_indptr = torch.tensor([0, 5], dtype=torch.int32)  # single sequence
+    d, r = 3, 2  # keep values %3 == 2
+
+    remap, _, _ = apply_dcp_filter_and_remap(kv_indices, kv_indptr, d, r)
+    # kept: [2,5,11] -> floor(/3) = [0,1,3] (order preserved)
+    assert torch.equal(remap, torch.tensor([0, 1, 3], dtype=torch.int32))
+
+
+def test_dcp_local_capacity_cpu():
+    # Ensure the per-rank pool reduces physical token capacity to ceil(size/d)
+    device = "cpu"
+    global_size = 100
+    page_size = 1
+    d = 4
+    local_size = math.ceil(global_size / d)
+
+    pool = DCPAwareMLATokenToKVPool(
+        size=global_size,
+        page_size=page_size,
+        dtype=torch.float32,
+        kv_lora_rank=16,
+        qk_rope_head_dim=16,
+        layer_num=2,
+        device=device,
+        enable_memory_saver=False,
+        dcp_rank=1,
+        dcp_world_size=d,
+        start_layer=0,
+        end_layer=1,
+    )
+
+    # Check allocated kv_buffer token dimension equals local_size + page_size (padded slot 0)
+    for buf in pool.kv_buffer:
+        assert buf.shape[0] == local_size + page_size
+
+


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).

## Summary by Sourcery

Enable Data-Centric Parallelism (DCP) for the MLA KV cache by introducing a DCP-aware token pool, wiring DCP filtering and index remapping into the FlashInfer backend and model runner, adjusting head counts in DeepSeek v2, and covering the new logic with targeted unit tests

New Features:
- Add DCPAwareMLATokenToKVPool to shard and remap KV cache buffers across DCP ranks
- Integrate DCP filtering and index remapping in FlashInfer MLA attention decoder and prefill paths
- Expand token pool capacity and conditionally instantiate DCP-aware KV pools in the model runner based on DCP world size
- Correct DeepSeek v2 attention head count to account for DCP

Tests:
- Add unit tests for DCP filtering and remapping logic and for validating physical location mapping
- Add test to verify local token buffer sizing in the DCP-aware pool