### PR TITLE
Wh/dcp dev 2

### DIFF
--- a/python/sglang/srt/layers/attention/utils.py
+++ b/python/sglang/srt/layers/attention/utils.py
@@ -103,22 +103,35 @@ def create_flashmla_kv_indices_triton(
 
 
 @triton.jit
-def _correct_attn_cp_out_kernel(outputs_ptr, new_output_ptr, lses_ptr,
-                                vlse_ptr, outputs_stride_B, outputs_stride_H,
-                                outputs_stride_D, lses_stride_N, lses_stride_B,
-                                lses_stride_H, lse_idx, HEAD_DIM: tl.constexpr,
-                                N_ROUNDED: tl.constexpr):
+def _correct_attn_cp_out_kernel(
+    outputs_ptr,
+    new_output_ptr,
+    lses_ptr,
+    vlse_ptr,
+    outputs_stride_B,
+    outputs_stride_H,
+    outputs_stride_D,
+    lses_stride_N,
+    lses_stride_B,
+    lses_stride_H,
+    lse_idx,
+    HEAD_DIM: tl.constexpr,
+    N_ROUNDED: tl.constexpr,
+):
     """
     Apply the all-gathered lses to correct each local rank's attention
     output. we still need perform a cross-rank reduction to obtain the
     final attention output.
+
     Args:
-        output: [ B, H, D ]
-        lses   : [ N, B, H ]
-        cp, batch, q_heads, v_head_dim
-    Return:
-        output: [ B, H, D ]
-        lse   : [ B, H ]
+        outputs_ptr (triton.PointerType):
+            Pointer to input tensor of shape [ B, H, D ]
+        lses_ptr (triton.PointerType):
+            Pointer to input tensor of shape [ N, B, H ]
+        new_output_ptr (triton.PointerType):
+            Pointer to output tensor of shape [ B, H, D ]
+        vlse_ptr (triton.PointerType):
+            Pointer to output tensor of shape [ B, H ]
     """
     batch_idx = tl.program_id(axis=0).to(tl.int64)
     head_idx = tl.program_id(axis=1).to(tl.int64)
@@ -126,13 +139,17 @@ def _correct_attn_cp_out_kernel(outputs_ptr, new_output_ptr, lses_ptr,
     num_n_offsets = tl.arange(0, N_ROUNDED)
 
     # shape = [N]
-    lse_offsets = num_n_offsets * lses_stride_N + batch_idx * \
-        lses_stride_B + head_idx * lses_stride_H
+    lse_offsets = (
+        num_n_offsets * lses_stride_N
+        + batch_idx * lses_stride_B
+        + head_idx * lses_stride_H
+    )
 
     # calc final lse
     lse = tl.load(lses_ptr + lse_offsets)
-    lse = tl.where((lse != lse) | (lse == float('inf')), -float('inf'), lse)
+    lse = tl.where((lse != lse) | (lse == float("inf")), -float("inf"), lse)
     lse_max = tl.max(lse, axis=0)
+    lse_max = tl.where(lse_max == -float("inf"), 0, lse_max)
     lse -= lse_max
     lse_exp = tl.exp(lse)
     lse_acc = tl.sum(lse_exp, axis=0)
@@ -143,18 +160,23 @@ def _correct_attn_cp_out_kernel(outputs_ptr, new_output_ptr, lses_ptr,
     tl.store(vlse_ptr + lse_offsets, lse)
 
     # shape = [D]
-    output_offsets = batch_idx * outputs_stride_B + \
-                    head_idx * outputs_stride_H + \
-                    d_offsets * outputs_stride_D
+    output_offsets = (
+        batch_idx * outputs_stride_B
+        + head_idx * outputs_stride_H
+        + d_offsets * outputs_stride_D
+    )
 
     # correct output
-    lse_offset = lse_idx * lses_stride_N + batch_idx * \
-        lses_stride_B + head_idx * lses_stride_H
+    lse_offset = (
+        lse_idx * lses_stride_N + batch_idx * lses_stride_B + head_idx * lses_stride_H
+    )
     lse_tmp = tl.load(lses_ptr + lse_offset)
     lse_finally = lse_tmp - lse
     lse_finally = tl.where(
-        (lse_finally != lse_finally) | (lse_finally == float('inf')),
-        -float('inf'), lse_finally)
+        (lse_finally != lse_finally) | (lse_finally == float("inf")),
+        -float("inf"),
+        lse_finally,
+    )
     factor = tl.exp(lse_finally)
     output = tl.load(outputs_ptr + output_offsets)
     output = output * factor
@@ -163,8 +185,7 @@ def _correct_attn_cp_out_kernel(outputs_ptr, new_output_ptr, lses_ptr,
 
 
 class CPTritonContext:
-    """ The CPTritonContext is used to avoid recompilation of the Triton JIT.
-    """
+    """The CPTritonContext is used to avoid recompilation of the Triton JIT."""
 
     def __init__(self):
         self.inner_kernel = None
@@ -176,41 +197,80 @@ class CPTritonContext:
             self.inner_kernel[grid](*regular_args)
 
 
-def correct_attn_out(out: torch.Tensor, lses: torch.Tensor, cp_rank: int,
-                     ctx: CPTritonContext):
-    """
-    Apply the all-gathered lses to correct each local rank's attention
-    output. we still need perform a cross-rank reduction to obtain the
-    final attention output.
+def correct_attn_out(
+    out: torch.Tensor, lses: torch.Tensor, cp_rank: int, ctx: CPTritonContext
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Correct the attention output using the all-gathered lses.
+
     Args:
-        output: [ B, H, D ]
-        lses   : [ N, B, H ]
-    Return:
-        output: [ B, H, D ]
-        lse   : [ B, H ]
+        out: Tensor of shape [ B, H, D ]
+        lses: Tensor of shape [ N, B, H ]
+        cp_rank: Current rank in the context-parallel group
+        ctx: Triton context to avoid recompilation
+
+    Returns:
+        Tuple of (out, lse) with corrected attention and final log-sum-exp.
     """
     if ctx is None:
         ctx = CPTritonContext()
 
-    lse = torch.empty_like(lses[0])
+    # --- Normalize to 3D views ---
+    if out.ndim == 4 and out.shape[1] == 1:
+        out = out.squeeze(1)
+    assert out.ndim == 3, f"expected out [B,H,D] or [B,1,H,D], got {tuple(out.shape)}"
 
-    grid = (out.shape[0], out.shape[1], 1)
-    regular_args = (out, out, lses, lse, *out.stride(), *lses.stride(),
-                    cp_rank)
-    const_args = {
-        "HEAD_DIM": out.shape[-1],
-        "N_ROUNDED": lses.shape[0],
-    }
+    if lses.ndim == 4 and lses.shape[-1] == 1:
+        lses = lses.squeeze(-1)
+    if lses.ndim == 4 and lses.shape[1] == 1:
+        lses = lses.squeeze(1)
+    assert lses.ndim == 3, (
+        f"expected lses [N,B,H] (optionally with a 1-sized extra dim), "
+        f"got {tuple(lses.shape)}"
+    )
 
-    ctx.call_kernel(_correct_attn_cp_out_kernel, grid, *regular_args,
-                    **const_args)
+    B, H, D = out.shape
+    N = lses.shape[0]
+
+    # Strides after we normalized shapes to 3-D views.  The kernel computes
+    # offsets for `vlse_ptr` using lses_stride_B/H, so the output buffer must
+    # have the same B/H stride layout as a slice of `lses`.
+    o_sB, o_sH, o_sD = out.stride()
+    l_sN, l_sB, l_sH = lses.stride()
+
+    # Allocate LSE with the same B/H strides as `lses` so writes land correctly
+    # even when `lses` is a non-contiguous view (e.g., 4-D to 3-D squeeze).
+    lse = torch.empty_strided(
+        (B, H), (l_sB, l_sH), device=lses.device, dtype=lses.dtype
+    )
+
+    # Kernel launch config
+    grid = (B, H, 1)
+
+    regular_args = (
+        out,
+        out,
+        lses,
+        lse,
+        o_sB,
+        o_sH,
+        o_sD,
+        l_sN,
+        l_sB,
+        l_sH,
+        cp_rank,
+    )
+    const_args = {"HEAD_DIM": D, "N_ROUNDED": N}
+
+    ctx.call_kernel(_correct_attn_cp_out_kernel, grid, *regular_args, **const_args)
     return out, lse
 
 
-def cp_lse_ag_out_rs(cp_attn_out: torch.Tensor,
-                     cp_attn_lse: torch.Tensor,
-                     cp_group: GroupCoordinator,
-                     ctx: CPTritonContext = None):
+def cp_lse_ag_out_rs(
+    cp_attn_out: torch.Tensor,
+    cp_attn_lse: torch.Tensor,
+    cp_group: GroupCoordinator,
+    ctx: CPTritonContext = None
+):
     """
     cp_attn_out: [ B, H, D ]
     cp_attn_lse: [ B, H ]
@@ -221,9 +281,11 @@ def cp_lse_ag_out_rs(cp_attn_out: torch.Tensor,
     if ctx is None:
         ctx = CPTritonContext()
 
-    lses = torch.empty((cp_group.world_size, ) + cp_attn_lse.shape,
-                       dtype=cp_attn_lse.dtype,
-                       device=cp_attn_lse.device)
+    lses = torch.empty(
+        (cp_group.world_size, ) + cp_attn_lse.shape,
+        dtype=cp_attn_lse.dtype,
+        device=cp_attn_lse.device,
+    )
 
     cp_attn_lse = cp_attn_lse.contiguous()
     lses = cp_group.all_gather(cp_attn_lse, dim=0).view_as(lses)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1015,13 +1015,15 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             )
         return req_pool_indices
 
-    def alloc_token_slots(self, num_tokens: int, backup_state: bool = False):
+    def alloc_token_slots(
+        self, num_tokens: int, backup_state: bool = False, token_positions: Optional[torch.Tensor] = None
+    ):
         self._evict_tree_cache_if_needed(num_tokens)
 
         if backup_state:
             state = self.token_to_kv_pool_allocator.backup_state()
 
-        out_cache_loc = self.token_to_kv_pool_allocator.alloc(num_tokens)
+        out_cache_loc = self.token_to_kv_pool_allocator.alloc(num_tokens, token_positions=token_positions)
         if out_cache_loc is None:
             phase_str = "Prefill" if self.forward_mode.is_extend() else "Decode"
             error_msg = (
@@ -1048,6 +1050,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         last_loc: torch.Tensor,
         extend_num_tokens: int,
         backup_state: bool = False,
+        token_positions: Optional[torch.Tensor] = None,
     ):
         # Over estimate the number of tokens: assume each request needs a new page.
         num_tokens = (
@@ -1066,6 +1069,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             seq_lens_cpu,
             last_loc,
             extend_num_tokens,
+            token_positions=token_positions,
         )
         if out_cache_loc is None:
             error_msg = (
@@ -1087,6 +1091,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         seq_lens_cpu: torch.Tensor,
         last_loc: torch.Tensor,
         backup_state: bool = False,
+        token_positions: Optional[torch.Tensor] = None,
     ):
         # Over estimate the number of tokens: assume each request needs a new page.
         num_tokens = len(seq_lens) * self.token_to_kv_pool_allocator.page_size
@@ -1096,7 +1101,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             state = self.token_to_kv_pool_allocator.backup_state()
 
         out_cache_loc = self.token_to_kv_pool_allocator.alloc_decode(
-            seq_lens, seq_lens_cpu, last_loc
+            seq_lens, seq_lens_cpu, last_loc, token_positions=token_positions
         )
         if out_cache_loc is None:
             error_msg = (
@@ -1274,8 +1279,26 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         )
 
         # Allocate memory
+        # Build token positions for DCP interleaved storage
+        token_positions = None
+        try:
+            from sglang.srt.distributed.parallel_state import get_dcp_world_size
+            if get_dcp_world_size() > 1:
+                # Build token positions: each token's position in its sequence (0-indexed)
+                token_positions_list = []
+                for req in reqs:
+                    seq_len = len(req.fill_ids)
+                    # Positions for extend tokens (after prefix)
+                    pre_len = len(req.prefix_indices)
+                    extend_positions = torch.arange(pre_len, seq_len, dtype=torch.int64)
+                    token_positions_list.append(extend_positions)
+                if token_positions_list:
+                    token_positions = torch.cat(token_positions_list).to(self.device)
+        except (ImportError, AttributeError):
+            pass
+        
         if self.token_to_kv_pool_allocator.page_size == 1:
-            out_cache_loc = self.alloc_token_slots(extend_num_tokens)
+            out_cache_loc = self.alloc_token_slots(extend_num_tokens, token_positions=token_positions)
         else:
             last_loc = [
                 (
@@ -1292,6 +1315,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 seq_lens_cpu,
                 torch.cat(last_loc),
                 extend_num_tokens,
+                token_positions=token_positions,
             )
 
         # Write allocated tokens to req_to_token_pool
@@ -1706,14 +1730,24 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 )
 
         # Allocate memory
+        # Build token positions for DCP interleaved storage
+        token_positions = None
+        try:
+            from sglang.srt.distributed.parallel_state import get_dcp_world_size
+            if get_dcp_world_size() > 1:
+                # For decode, token position is seq_len - 1 (the last token position)
+                token_positions = (self.seq_lens - 1).to(torch.int64)
+        except (ImportError, AttributeError):
+            pass
+        
         if self.token_to_kv_pool_allocator.page_size == 1:
-            self.out_cache_loc = self.alloc_token_slots(bs)
+            self.out_cache_loc = self.alloc_token_slots(bs, token_positions=token_positions)
         else:
             last_loc = self.req_to_token_pool.req_to_token[
                 self.req_pool_indices, self.seq_lens - 2
             ]
             self.out_cache_loc = self.alloc_paged_token_slots_decode(
-                self.seq_lens, self.seq_lens_cpu, last_loc
+                self.seq_lens, self.seq_lens_cpu, last_loc, token_positions=token_positions
             )
 
         self.req_to_token_pool.write(

--- a/python/sglang/srt/mem_cache/allocator.py
+++ b/python/sglang/srt/mem_cache/allocator.py
@@ -180,8 +180,8 @@ class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             # Save unused indices before setting placeholder
             unused_indices = select_index[~token_rank_mask].clone()
             
-            # Set placeholder (0) for tokens not on this rank
-            select_index[~token_rank_mask] = 0
+            # Set placeholder (-1) for tokens not on this rank
+            select_index[~token_rank_mask] = -1
             
             # Return unused indices to free pool
             if unused_indices.numel() > 0:
@@ -527,7 +527,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
 
         bs = len(prefix_lens)
-        
+
         # Filter tokens based on DCP interleaved storage if enabled
         if token_positions is not None and get_dcp_world_size() > 1:
             # Create mask for tokens that belong to this rank
@@ -567,7 +567,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             page_size=self.page_size,
             prefix_lens=prefix_lens_cpu,
         )
-        
+
         # Filter out indices for tokens not belonging to this rank
         if token_rank_mask is not None:
             # Save unused indices before setting placeholder
@@ -581,8 +581,8 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             else:
                 actual_pages_needed = 0
 
-            # Set placeholder (0) for tokens not on this rank
-            out_indices[~token_rank_mask] = 0
+            # Set placeholder (-1) for tokens not on this rank
+            out_indices[~token_rank_mask] = -1
 
             # Free pages that were allocated for tokens not on this rank
             if unused_indices.numel() > 0:
@@ -625,7 +625,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             )
 
         bs = len(seq_lens)
-        
+
         # Filter tokens based on DCP interleaved storage if enabled
         if token_positions is not None and get_dcp_world_size() > 1:
             # Create mask for tokens that belong to this rank
@@ -668,8 +668,8 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             else:
                 actual_pages_needed = 0
 
-            # Set placeholder (0) for tokens not on this rank
-            out_indices[~token_rank_mask] = 0
+            # Set placeholder (-1) for tokens not on this rank
+            out_indices[~token_rank_mask] = -1
 
             # Free pages that were allocated for tokens not on this rank
             if unused_indices.numel() > 0:

--- a/python/sglang/srt/mem_cache/allocator.py
+++ b/python/sglang/srt/mem_cache/allocator.py
@@ -32,7 +32,12 @@ from sglang.srt.utils import get_bool_env_var, get_num_new_pages, next_power_of_
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import KVCache
 
-from sglang.srt.distributed.parallel_state import get_dcp_world_size, get_dcp_rank
+from sglang.srt.distributed.parallel_state import (
+    get_dcp_world_size, get_dcp_rank, get_tensor_model_parallel_rank
+)
+
+import logging
+logger = logging.getLogger(__name__)
 
 
 class BaseTokenToKVPoolAllocator(abc.ABC):
@@ -191,7 +196,8 @@ class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                         self.release_pages = torch.cat((self.release_pages, unused_indices))
                     else:
                         self.free_pages = torch.cat((self.free_pages, unused_indices))
-        
+
+        logger.info(f"tp_rank={get_tensor_model_parallel_rank()}, select_index={select_index}, token_rank_mask={token_rank_mask}")
         return select_index
 
     def free(self, free_index: torch.Tensor):

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1239,7 +1239,7 @@ class MLATokenToKVPool(KVCache):
         if not valid_mask.all():
             loc = loc[valid_mask]
             cache_k = cache_k[valid_mask]
-            cache_v = cache_v[valid_mask]
+            # cache_v = cache_v[valid_mask]
 
         if loc.numel() == 0:
             return

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1061,7 +1061,9 @@ def set_mla_kv_buffer_kernel(
     mask = offs < total_dim
 
     loc = tl.load(loc_ptr + pid_loc)
-    dst_ptr = kv_buffer_ptr + loc * buffer_stride + offs
+    is_valid = loc >= 0
+    safe_loc = tl.where(is_valid, loc, 0)
+    dst_ptr = kv_buffer_ptr + safe_loc * buffer_stride + offs
 
     if base + BLOCK <= nope_dim:
         src = tl.load(
@@ -1075,7 +1077,7 @@ def set_mla_kv_buffer_kernel(
             mask=mask,
         )
 
-    tl.store(dst_ptr, src, mask=mask)
+    tl.store(dst_ptr, src, mask=mask & is_valid)
 
 
 def set_mla_kv_buffer_triton(
@@ -1232,17 +1234,10 @@ class MLATokenToKVPool(KVCache):
         layer_id = layer.layer_id
         assert not (self.use_nsa and self.nsa_kv_cache_store_fp8)
 
-        # Filter out invalid indices (e.g., -1 for non-local tokens in DCP mode)
-        # In DCP interleaved storage, tokens not belonging to this rank are marked
-        # with -1 to avoid overwriting the padded slot 0 (reserved for dummy outputs)
         valid_mask = loc >= 0
         if not valid_mask.all():
             loc = loc[valid_mask]
             cache_k = cache_k[valid_mask]
-            # cache_v = cache_v[valid_mask]
-
-        if loc.numel() == 0:
-            return
 
         if cache_k.dtype != self.dtype:
             cache_k = cache_k.to(self.dtype)
@@ -1261,18 +1256,6 @@ class MLATokenToKVPool(KVCache):
         cache_k_rope: torch.Tensor,
     ):
         layer_id = layer.layer_id
-
-        # Filter out invalid indices (e.g., -1 for non-local tokens in DCP mode)
-        # In DCP interleaved storage, tokens not belonging to this rank are marked
-        # with -1 to avoid overwriting the padded slot 0 (reserved for dummy outputs)
-        valid_mask = loc >= 0
-        if not valid_mask.all():
-            loc = loc[valid_mask]
-            cache_k_nope = cache_k_nope[valid_mask]
-            cache_k_rope = cache_k_rope[valid_mask]
-
-        if loc.numel() == 0:
-            return
 
         if self.use_nsa and self.nsa_kv_cache_store_fp8:
             # original cache_k: (num_tokens, num_heads 1, hidden 576); we unsqueeze the page_size=1 dim here

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -66,6 +66,7 @@ suites = {
         TestFile("rl/test_update_weights_from_tensor.py", 48),
         TestFile("test_abort.py", 51),
         TestFile("test_create_kvindices.py", 2),
+        TestFile("test_dcp_interleaved_storage.py", 5),
         TestFile("test_chunked_prefill.py", 313),
         TestFile("test_deterministic.py", 300),
         TestFile("test_eagle_infer_a.py", 370),

--- a/test/srt/test_dcp_interleaved_storage.py
+++ b/test/srt/test_dcp_interleaved_storage.py
@@ -71,11 +71,11 @@ class TestDCPInterleavedStorage(unittest.TestCase):
         # Verify: indices for rank 1 tokens (positions 1, 3) should be 0 (placeholder)
         self.assertIsNotNone(indices)
         self.assertEqual(len(indices), need_size)
-        self.assertEqual(indices[1].item(), 0)  # Position 1 -> rank 1 -> placeholder
-        self.assertEqual(indices[3].item(), 0)  # Position 3 -> rank 1 -> placeholder
-        self.assertNotEqual(indices[0].item(), 0)  # Position 0 -> rank 0 -> allocated
-        self.assertNotEqual(indices[2].item(), 0)  # Position 2 -> rank 0 -> allocated
-        self.assertNotEqual(indices[4].item(), 0)  # Position 4 -> rank 0 -> allocated
+        self.assertEqual(indices[1].item(), -1)  # Position 1 -> rank 1 -> placeholder
+        self.assertEqual(indices[3].item(), -1)  # Position 3 -> rank 1 -> placeholder
+        self.assertNotEqual(indices[0].item(), -1)  # Position 0 -> rank 0 -> allocated
+        self.assertNotEqual(indices[2].item(), -1)  # Position 2 -> rank 0 -> allocated
+        self.assertNotEqual(indices[4].item(), -1)  # Position 4 -> rank 0 -> allocated
 
         # Verify: only 3 tokens were actually allocated (for rank 0)
         # The unused indices should be returned to free pool
@@ -109,11 +109,11 @@ class TestDCPInterleavedStorage(unittest.TestCase):
         # Verify: indices for rank 0 tokens (positions 0, 2, 4) should be 0 (placeholder)
         self.assertIsNotNone(indices)
         self.assertEqual(len(indices), need_size)
-        self.assertEqual(indices[0].item(), 0)  # Position 0 -> rank 0 -> placeholder
-        self.assertEqual(indices[2].item(), 0)  # Position 2 -> rank 0 -> placeholder
-        self.assertEqual(indices[4].item(), 0)  # Position 4 -> rank 0 -> placeholder
-        self.assertNotEqual(indices[1].item(), 0)  # Position 1 -> rank 1 -> allocated
-        self.assertNotEqual(indices[3].item(), 0)  # Position 3 -> rank 1 -> allocated
+        self.assertEqual(indices[0].item(), -1)  # Position 0 -> rank 0 -> placeholder
+        self.assertEqual(indices[2].item(), -1)  # Position 2 -> rank 0 -> placeholder
+        self.assertEqual(indices[4].item(), -1)  # Position 4 -> rank 0 -> placeholder
+        self.assertNotEqual(indices[1].item(), -1)  # Position 1 -> rank 1 -> allocated
+        self.assertNotEqual(indices[3].item(), -1)  # Position 3 -> rank 1 -> allocated
 
         # Verify: only 2 tokens were actually allocated (for rank 1)
         final_available = allocator.available_size()
@@ -193,11 +193,11 @@ class TestDCPInterleavedStorage(unittest.TestCase):
         # Verify: indices for rank 1 tokens (positions 11, 13) should be 0 (placeholder)
         self.assertIsNotNone(indices)
         self.assertEqual(len(indices), extend_num_tokens)
-        self.assertEqual(indices[1].item(), 0)  # Position 11 -> rank 1 -> placeholder
-        self.assertEqual(indices[3].item(), 0)  # Position 13 -> rank 1 -> placeholder
-        self.assertNotEqual(indices[0].item(), 0)  # Position 10 -> rank 0 -> allocated
-        self.assertNotEqual(indices[2].item(), 0)  # Position 12 -> rank 0 -> allocated
-        self.assertNotEqual(indices[4].item(), 0)  # Position 14 -> rank 0 -> allocated
+        self.assertEqual(indices[1].item(), -1)  # Position 11 -> rank 1 -> placeholder
+        self.assertEqual(indices[3].item(), -1)  # Position 13 -> rank 1 -> placeholder
+        self.assertNotEqual(indices[0].item(), -1)  # Position 10 -> rank 0 -> allocated
+        self.assertNotEqual(indices[2].item(), -1)  # Position 12 -> rank 0 -> allocated
+        self.assertNotEqual(indices[4].item(), -1)  # Position 14 -> rank 0 -> allocated
 
     @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
     @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
@@ -235,9 +235,9 @@ class TestDCPInterleavedStorage(unittest.TestCase):
         # Verify: indices for rank 1 token (position 6) should be 0 (placeholder)
         self.assertIsNotNone(indices)
         self.assertEqual(len(indices), bs)
-        self.assertNotEqual(indices[1].item(), 0)  # Position 6 -> rank 1 -> allocated
-        self.assertEqual(indices[0].item(), 0)  # Position 5 -> rank 0 -> placeholder
-        self.assertEqual(indices[2].item(), 0)  # Position 7 -> rank 0 -> placeholder
+        self.assertNotEqual(indices[1].item(), -1)  # Position 6 -> rank 1 -> allocated
+        self.assertEqual(indices[0].item(), -1)  # Position 5 -> rank 0 -> placeholder
+        self.assertEqual(indices[2].item(), -1)  # Position 7 -> rank 0 -> placeholder
 
     @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
     @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
@@ -307,12 +307,12 @@ class TestDCPInterleavedStorage(unittest.TestCase):
         # Verify: rank 1 should only store positions 1 and 4
         self.assertIsNotNone(indices)
         self.assertEqual(len(indices), need_size)
-        self.assertEqual(indices[0].item(), 0)  # Position 0 -> rank 0 -> placeholder
-        self.assertNotEqual(indices[1].item(), 0)  # Position 1 -> rank 1 -> allocated
-        self.assertEqual(indices[2].item(), 0)  # Position 2 -> rank 2 -> placeholder
-        self.assertEqual(indices[3].item(), 0)  # Position 3 -> rank 0 -> placeholder
-        self.assertNotEqual(indices[4].item(), 0)  # Position 4 -> rank 1 -> allocated
-        self.assertEqual(indices[5].item(), 0)  # Position 5 -> rank 2 -> placeholder
+        self.assertEqual(indices[0].item(), -1)  # Position 0 -> rank 0 -> placeholder
+        self.assertNotEqual(indices[1].item(), -1)  # Position 1 -> rank 1 -> allocated
+        self.assertEqual(indices[2].item(), -1)  # Position 2 -> rank 2 -> placeholder
+        self.assertEqual(indices[3].item(), -1)  # Position 3 -> rank 0 -> placeholder
+        self.assertNotEqual(indices[4].item(), -1)  # Position 4 -> rank 1 -> allocated
+        self.assertEqual(indices[5].item(), -1)  # Position 5 -> rank 2 -> placeholder
 
     @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
     @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
@@ -387,12 +387,12 @@ class TestDCPInterleavedStorage(unittest.TestCase):
             for pos in range(seq_len):
                 if pos % 4 == rank:
                     # This token belongs to current rank
-                    self.assertNotEqual(indices[pos].item(), 0,
+                    self.assertNotEqual(indices[pos].item(), -1,
                                       f"Rank {rank}, position {pos} should be allocated")
                     expected_count += 1
                 else:
                     # This token belongs to another rank
-                    self.assertEqual(indices[pos].item(), 0,
+                    self.assertEqual(indices[pos].item(), -1,
                                    f"Rank {rank}, position {pos} should be placeholder")
 
             # Verify: available_size decreased by expected_count
@@ -461,12 +461,12 @@ class TestDCPInterleavedStorage(unittest.TestCase):
             for i, pos in enumerate(range(prefix_len, seq_len)):
                 if pos % 4 == rank:
                     # This token belongs to current rank
-                    self.assertNotEqual(indices[i].item(), 0,
+                    self.assertNotEqual(indices[i].item(), -1,
                                       f"Rank {rank}, position {pos} should be allocated")
                     expected_count += 1
                 else:
                     # This token belongs to another rank
-                    self.assertEqual(indices[i].item(), 0,
+                    self.assertEqual(indices[i].item(), -1,
                                    f"Rank {rank}, position {pos} should be placeholder")
 
             # Verify: All allocated indices are unique
@@ -523,12 +523,12 @@ class TestDCPInterleavedStorage(unittest.TestCase):
                 token_pos = seq_len_val - 1  # Decode token position
                 if token_pos % 4 == rank:
                     # This token belongs to current rank
-                    self.assertNotEqual(indices[i].item(), 0,
+                    self.assertNotEqual(indices[i].item(), -1,
                                       f"Rank {rank}, request {i}, position {token_pos} should be allocated")
                     expected_count += 1
                 else:
                     # This token belongs to another rank
-                    self.assertEqual(indices[i].item(), 0,
+                    self.assertEqual(indices[i].item(), -1,
                                    f"Rank {rank}, request {i}, position {token_pos} should be placeholder")
 
             # Verify: All allocated indices are unique

--- a/test/srt/test_dcp_interleaved_storage.py
+++ b/test/srt/test_dcp_interleaved_storage.py
@@ -1,0 +1,320 @@
+"""
+Test DCP interleaved storage for KV cache allocators.
+
+This test verifies that tokens are correctly distributed across DCP ranks
+based on token_idx % dcp_world_size == dcp_rank.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.mem_cache.allocator import (
+    TokenToKVPoolAllocator,
+    PagedTokenToKVPoolAllocator,
+)
+
+
+class MockKVCache:
+    """Mock KVCache for testing."""
+
+    def __init__(self, size, dtype, device):
+        self.size = size
+        self.dtype = dtype
+        self.device = device
+
+    def get_cpu_copy(self, indices):
+        return None
+
+    def load_cpu_copy(self, kv_cache_cpu, indices):
+        pass
+
+
+class TestDCPInterleavedStorage(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.device = "cuda" if torch.cuda.is_available() else "cpu"
+        cls.dtype = torch.bfloat16
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.size = 100
+        self.page_size = 16
+        self.kvcache = MockKVCache(self.size, self.dtype, self.device)
+
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
+    def test_token_allocator_dcp_interleaved_page_size_1(self, mock_rank, mock_world_size):
+        """Test TokenToKVPoolAllocator with DCP interleaved storage (page_size=1)."""
+        # Setup: 2 DCP ranks, current rank is 0
+        mock_world_size.return_value = 2
+        mock_rank.return_value = 0
+
+        allocator = TokenToKVPoolAllocator(
+            size=self.size,
+            dtype=self.dtype,
+            device=self.device,
+            kvcache=self.kvcache,
+            need_sort=False,
+        )
+
+        # Test: allocate 5 tokens with positions [0, 1, 2, 3, 4]
+        # Rank 0 should store: 0, 2, 4 (token_idx % 2 == 0)
+        # Rank 1 should store: 1, 3 (token_idx % 2 == 1)
+        token_positions = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64, device=self.device)
+        need_size = 5
+
+        initial_available = allocator.available_size()
+        indices = allocator.alloc(need_size, token_positions=token_positions)
+
+        # Verify: indices for rank 1 tokens (positions 1, 3) should be 0 (placeholder)
+        self.assertIsNotNone(indices)
+        self.assertEqual(len(indices), need_size)
+        self.assertEqual(indices[1].item(), 0)  # Position 1 -> rank 1 -> placeholder
+        self.assertEqual(indices[3].item(), 0)  # Position 3 -> rank 1 -> placeholder
+        self.assertNotEqual(indices[0].item(), 0)  # Position 0 -> rank 0 -> allocated
+        self.assertNotEqual(indices[2].item(), 0)  # Position 2 -> rank 0 -> allocated
+        self.assertNotEqual(indices[4].item(), 0)  # Position 4 -> rank 0 -> allocated
+
+        # Verify: only 3 tokens were actually allocated (for rank 0)
+        # The unused indices should be returned to free pool
+        final_available = allocator.available_size()
+        # Should have allocated 3 tokens (for rank 0), so available_size decreased by 3
+        self.assertEqual(initial_available - final_available, 3)
+
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
+    def test_token_allocator_dcp_interleaved_rank_1(self, mock_rank, mock_world_size):
+        """Test TokenToKVPoolAllocator with DCP interleaved storage, rank 1."""
+        # Setup: 2 DCP ranks, current rank is 1
+        mock_world_size.return_value = 2
+        mock_rank.return_value = 1
+
+        allocator = TokenToKVPoolAllocator(
+            size=self.size,
+            dtype=self.dtype,
+            device=self.device,
+            kvcache=self.kvcache,
+            need_sort=False,
+        )
+
+        # Test: allocate 5 tokens with positions [0, 1, 2, 3, 4]
+        token_positions = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64, device=self.device)
+        need_size = 5
+
+        initial_available = allocator.available_size()
+        indices = allocator.alloc(need_size, token_positions=token_positions)
+
+        # Verify: indices for rank 0 tokens (positions 0, 2, 4) should be 0 (placeholder)
+        self.assertIsNotNone(indices)
+        self.assertEqual(len(indices), need_size)
+        self.assertEqual(indices[0].item(), 0)  # Position 0 -> rank 0 -> placeholder
+        self.assertEqual(indices[2].item(), 0)  # Position 2 -> rank 0 -> placeholder
+        self.assertEqual(indices[4].item(), 0)  # Position 4 -> rank 0 -> placeholder
+        self.assertNotEqual(indices[1].item(), 0)  # Position 1 -> rank 1 -> allocated
+        self.assertNotEqual(indices[3].item(), 0)  # Position 3 -> rank 1 -> allocated
+
+        # Verify: only 2 tokens were actually allocated (for rank 1)
+        final_available = allocator.available_size()
+        self.assertEqual(initial_available - final_available, 2)
+
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
+    def test_token_allocator_no_dcp(self, mock_rank, mock_world_size):
+        """Test TokenToKVPoolAllocator without DCP (dcp_world_size=1)."""
+        # Setup: DCP disabled (world_size=1)
+        mock_world_size.return_value = 1
+        mock_rank.return_value = 0
+
+        allocator = TokenToKVPoolAllocator(
+            size=self.size,
+            dtype=self.dtype,
+            device=self.device,
+            kvcache=self.kvcache,
+            need_sort=False,
+        )
+
+        token_positions = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64, device=self.device)
+        need_size = 5
+
+        initial_available = allocator.available_size()
+        indices = allocator.alloc(need_size, token_positions=token_positions)
+
+        # Verify: all tokens should be allocated (no filtering)
+        self.assertIsNotNone(indices)
+        self.assertEqual(len(indices), need_size)
+        self.assertTrue(torch.all(indices > 0))  # All indices should be allocated
+
+        # Verify: all 5 tokens were allocated
+        final_available = allocator.available_size()
+        self.assertEqual(initial_available - final_available, 5)
+
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
+    def test_paged_allocator_extend_dcp_interleaved(self, mock_rank, mock_world_size):
+        """Test PagedTokenToKVPoolAllocator.alloc_extend with DCP interleaved storage."""
+        # Setup: 2 DCP ranks, current rank is 0
+        mock_world_size.return_value = 2
+        mock_rank.return_value = 0
+
+        allocator = PagedTokenToKVPoolAllocator(
+            size=self.size,
+            page_size=self.page_size,
+            dtype=self.dtype,
+            device=self.device,
+            kvcache=self.kvcache,
+            need_sort=False,
+        )
+
+        # Test: extend with 5 tokens at positions [10, 11, 12, 13, 14]
+        # Rank 0 should store: 10, 12, 14 (token_idx % 2 == 0)
+        # Rank 1 should store: 11, 13 (token_idx % 2 == 1)
+        bs = 1
+        prefix_lens = torch.tensor([10], dtype=torch.int64, device=self.device)
+        prefix_lens_cpu = torch.tensor([10], dtype=torch.int64)
+        seq_lens = torch.tensor([15], dtype=torch.int64, device=self.device)
+        seq_lens_cpu = torch.tensor([15], dtype=torch.int64)
+        last_loc = torch.tensor([9], dtype=torch.int64, device=self.device)
+        extend_num_tokens = 5
+        token_positions = torch.tensor([10, 11, 12, 13, 14], dtype=torch.int64, device=self.device)
+
+        initial_available = allocator.available_size()
+        indices = allocator.alloc_extend(
+            prefix_lens=prefix_lens,
+            prefix_lens_cpu=prefix_lens_cpu,
+            seq_lens=seq_lens,
+            seq_lens_cpu=seq_lens_cpu,
+            last_loc=last_loc,
+            extend_num_tokens=extend_num_tokens,
+            token_positions=token_positions,
+        )
+
+        # Verify: indices for rank 1 tokens (positions 11, 13) should be 0 (placeholder)
+        self.assertIsNotNone(indices)
+        self.assertEqual(len(indices), extend_num_tokens)
+        self.assertEqual(indices[1].item(), 0)  # Position 11 -> rank 1 -> placeholder
+        self.assertEqual(indices[3].item(), 0)  # Position 13 -> rank 1 -> placeholder
+        self.assertNotEqual(indices[0].item(), 0)  # Position 10 -> rank 0 -> allocated
+        self.assertNotEqual(indices[2].item(), 0)  # Position 12 -> rank 0 -> allocated
+        self.assertNotEqual(indices[4].item(), 0)  # Position 14 -> rank 0 -> allocated
+
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
+    def test_paged_allocator_decode_dcp_interleaved(self, mock_rank, mock_world_size):
+        """Test PagedTokenToKVPoolAllocator.alloc_decode with DCP interleaved storage."""
+        # Setup: 2 DCP ranks, current rank is 0
+        mock_world_size.return_value = 2
+        mock_rank.return_value = 0
+
+        allocator = PagedTokenToKVPoolAllocator(
+            size=self.size,
+            page_size=self.page_size,
+            dtype=self.dtype,
+            device=self.device,
+            kvcache=self.kvcache,
+            need_sort=False,
+        )
+
+        # Test: decode with 3 requests at positions [5, 6, 7]
+        # Rank 0 should store: 5, 7 (token_idx % 2 == 0)
+        # Rank 1 should store: 6 (token_idx % 2 == 1)
+        bs = 3
+        seq_lens = torch.tensor([6, 7, 8], dtype=torch.int64, device=self.device)
+        seq_lens_cpu = torch.tensor([6, 7, 8], dtype=torch.int64)
+        last_loc = torch.tensor([4, 5, 6], dtype=torch.int64, device=self.device)
+        token_positions = torch.tensor([5, 6, 7], dtype=torch.int64, device=self.device)
+
+        indices = allocator.alloc_decode(
+            seq_lens=seq_lens,
+            seq_lens_cpu=seq_lens_cpu,
+            last_loc=last_loc,
+            token_positions=token_positions,
+        )
+
+        # Verify: indices for rank 1 token (position 6) should be 0 (placeholder)
+        self.assertIsNotNone(indices)
+        self.assertEqual(len(indices), bs)
+        self.assertEqual(indices[1].item(), 0)  # Position 6 -> rank 1 -> placeholder
+        self.assertNotEqual(indices[0].item(), 0)  # Position 5 -> rank 0 -> allocated
+        self.assertNotEqual(indices[2].item(), 0)  # Position 7 -> rank 0 -> allocated
+
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
+    def test_paged_allocator_extend_no_token_positions(self, mock_rank, mock_world_size):
+        """Test PagedTokenToKVPoolAllocator.alloc_extend without token_positions (backward compatibility)."""
+        mock_world_size.return_value = 2
+        mock_rank.return_value = 0
+
+        allocator = PagedTokenToKVPoolAllocator(
+            size=self.size,
+            page_size=self.page_size,
+            dtype=self.dtype,
+            device=self.device,
+            kvcache=self.kvcache,
+            need_sort=False,
+        )
+
+        bs = 1
+        prefix_lens = torch.tensor([10], dtype=torch.int64, device=self.device)
+        prefix_lens_cpu = torch.tensor([10], dtype=torch.int64)
+        seq_lens = torch.tensor([15], dtype=torch.int64, device=self.device)
+        seq_lens_cpu = torch.tensor([15], dtype=torch.int64)
+        last_loc = torch.tensor([9], dtype=torch.int64, device=self.device)
+        extend_num_tokens = 5
+
+        # Should work without token_positions (backward compatibility)
+        indices = allocator.alloc_extend(
+            prefix_lens=prefix_lens,
+            prefix_lens_cpu=prefix_lens_cpu,
+            seq_lens=seq_lens,
+            seq_lens_cpu=seq_lens_cpu,
+            last_loc=last_loc,
+            extend_num_tokens=extend_num_tokens,
+            token_positions=None,
+        )
+
+        # Verify: all tokens should be allocated (no filtering when token_positions is None)
+        self.assertIsNotNone(indices)
+        self.assertEqual(len(indices), extend_num_tokens)
+        self.assertTrue(torch.all(indices > 0))  # All indices should be allocated
+
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
+    def test_dcp_3_ranks(self, mock_rank, mock_world_size):
+        """Test with 3 DCP ranks."""
+        # Setup: 3 DCP ranks, current rank is 1
+        mock_world_size.return_value = 3
+        mock_rank.return_value = 1
+
+        allocator = TokenToKVPoolAllocator(
+            size=self.size,
+            dtype=self.dtype,
+            device=self.device,
+            kvcache=self.kvcache,
+            need_sort=False,
+        )
+
+        # Test: allocate 6 tokens with positions [0, 1, 2, 3, 4, 5]
+        # Rank 0 should store: 0, 3 (token_idx % 3 == 0)
+        # Rank 1 should store: 1, 4 (token_idx % 3 == 1)
+        # Rank 2 should store: 2, 5 (token_idx % 3 == 2)
+        token_positions = torch.tensor([0, 1, 2, 3, 4, 5], dtype=torch.int64, device=self.device)
+        need_size = 6
+
+        indices = allocator.alloc(need_size, token_positions=token_positions)
+
+        # Verify: rank 1 should only store positions 1 and 4
+        self.assertIsNotNone(indices)
+        self.assertEqual(len(indices), need_size)
+        self.assertEqual(indices[0].item(), 0)  # Position 0 -> rank 0 -> placeholder
+        self.assertNotEqual(indices[1].item(), 0)  # Position 1 -> rank 1 -> allocated
+        self.assertEqual(indices[2].item(), 0)  # Position 2 -> rank 2 -> placeholder
+        self.assertEqual(indices[3].item(), 0)  # Position 3 -> rank 0 -> placeholder
+        self.assertNotEqual(indices[4].item(), 0)  # Position 4 -> rank 1 -> allocated
+        self.assertEqual(indices[5].item(), 0)  # Position 5 -> rank 2 -> placeholder
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/test/srt/test_dcp_interleaved_storage.py
+++ b/test/srt/test_dcp_interleaved_storage.py
@@ -217,8 +217,8 @@ class TestDCPInterleavedStorage(unittest.TestCase):
         )
 
         # Test: decode with 3 requests at positions [5, 6, 7]
-        # Rank 0 should store: 5, 7 (token_idx % 2 == 0)
-        # Rank 1 should store: 6 (token_idx % 2 == 1)
+        # Rank 1 should store: 5, 7 (token_idx % 2 == 1)
+        # Rank 0 should store: 6 (token_idx % 2 == 0)
         bs = 3
         seq_lens = torch.tensor([6, 7, 8], dtype=torch.int64, device=self.device)
         seq_lens_cpu = torch.tensor([6, 7, 8], dtype=torch.int64)
@@ -235,9 +235,9 @@ class TestDCPInterleavedStorage(unittest.TestCase):
         # Verify: indices for rank 1 token (position 6) should be 0 (placeholder)
         self.assertIsNotNone(indices)
         self.assertEqual(len(indices), bs)
-        self.assertEqual(indices[1].item(), 0)  # Position 6 -> rank 1 -> placeholder
-        self.assertNotEqual(indices[0].item(), 0)  # Position 5 -> rank 0 -> allocated
-        self.assertNotEqual(indices[2].item(), 0)  # Position 7 -> rank 0 -> allocated
+        self.assertNotEqual(indices[1].item(), 0)  # Position 6 -> rank 1 -> allocated
+        self.assertEqual(indices[0].item(), 0)  # Position 5 -> rank 0 -> placeholder
+        self.assertEqual(indices[2].item(), 0)  # Position 7 -> rank 0 -> placeholder
 
     @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
     @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
@@ -314,7 +314,310 @@ class TestDCPInterleavedStorage(unittest.TestCase):
         self.assertNotEqual(indices[4].item(), 0)  # Position 4 -> rank 1 -> allocated
         self.assertEqual(indices[5].item(), 0)  # Position 5 -> rank 2 -> placeholder
 
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
+    def test_multiple_allocs_with_free(self, mock_rank, mock_world_size):
+        """Test multiple allocs followed by free operations."""
+        # Setup: 2 DCP ranks, current rank is 0
+        mock_world_size.return_value = 2
+        mock_rank.return_value = 0
+
+        allocator = TokenToKVPoolAllocator(
+            size=100,
+            dtype=self.dtype,
+            device=self.device,
+            kvcache=self.kvcache,
+            need_sort=False,
+        )
+
+        # First allocation
+        token_positions_1 = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64, device=self.device)
+        indices_1 = allocator.alloc(5, token_positions=token_positions_1)
+        available_after_alloc1 = allocator.available_size()
+
+        # Free the allocated indices (only the non-placeholder ones)
+        rank_0_indices_1 = indices_1[indices_1 > 0]
+        allocator.free(rank_0_indices_1)
+        available_after_free1 = allocator.available_size()
+
+        # Verify: available size increased after free
+        self.assertGreater(available_after_free1, available_after_alloc1)
+
+        # Second allocation should be able to reuse freed indices
+        token_positions_2 = torch.tensor([5, 6, 7, 8, 9], dtype=torch.int64, device=self.device)
+        indices_2 = allocator.alloc(5, token_positions=token_positions_2)
+        self.assertIsNotNone(indices_2)
+
+        # Verify: The freed indices might be reused
+        rank_0_indices_2 = indices_2[indices_2 > 0]
+        # At least some indices should be valid
+        self.assertTrue(torch.all(rank_0_indices_2 > 0))
+
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
+    def test_non_paged_large_seq_4_ranks(self, mock_rank, mock_world_size):
+        """Test TokenToKVPoolAllocator with DCP interleaved storage, 4 ranks, large sequence."""
+        # Setup: 4 DCP ranks
+        mock_world_size.return_value = 4
+
+        # Test each rank
+        for rank in range(4):
+            mock_rank.return_value = rank
+
+            allocator = TokenToKVPoolAllocator(
+                size=1000,
+                dtype=self.dtype,
+                device=self.device,
+                kvcache=self.kvcache,
+                need_sort=False,
+            )
+
+            # Large sequence: 100 tokens with positions [0, 1, 2, ..., 99]
+            seq_len = 100
+            token_positions = torch.arange(seq_len, dtype=torch.int64, device=self.device)
+
+            initial_available = allocator.available_size()
+            indices = allocator.alloc(seq_len, token_positions=token_positions)
+
+            self.assertIsNotNone(indices, f"Rank {rank} allocation failed")
+            self.assertEqual(len(indices), seq_len)
+
+            # Verify: Each rank should store tokens where token_idx % 4 == rank
+            expected_count = 0
+            for pos in range(seq_len):
+                if pos % 4 == rank:
+                    # This token belongs to current rank
+                    self.assertNotEqual(indices[pos].item(), 0,
+                                      f"Rank {rank}, position {pos} should be allocated")
+                    expected_count += 1
+                else:
+                    # This token belongs to another rank
+                    self.assertEqual(indices[pos].item(), 0,
+                                   f"Rank {rank}, position {pos} should be placeholder")
+
+            # Verify: available_size decreased by expected_count
+            final_available = allocator.available_size()
+            self.assertEqual(initial_available - final_available, expected_count,
+                           f"Rank {rank} should allocate {expected_count} tokens")
+
+            # Verify: All allocated indices are unique
+            allocated_indices = indices[indices > 0]
+            self.assertEqual(len(allocated_indices), expected_count)
+            self.assertEqual(len(torch.unique(allocated_indices)), expected_count,
+                           f"Rank {rank} allocated indices should be unique")
+
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
+    def test_paged_large_seq_4_ranks_extend(self, mock_rank, mock_world_size):
+        """Test PagedTokenToKVPoolAllocator.alloc_extend with DCP interleaved storage, 4 ranks, large sequence."""
+        # Setup: 4 DCP ranks
+        mock_world_size.return_value = 4
+        page_size = 16
+
+        # Test each rank
+        for rank in range(4):
+            mock_rank.return_value = rank
+
+            allocator = PagedTokenToKVPoolAllocator(
+                size=1000,
+                page_size=page_size,
+                dtype=self.dtype,
+                device=self.device,
+                kvcache=self.kvcache,
+                need_sort=False,
+            )
+
+            # Large extend: prefix_len=20, seq_len=120, so extend_len=100
+            prefix_len = 20
+            allocator.alloc(prefix_len)
+            seq_len = 120
+            extend_len = seq_len - prefix_len
+
+            prefix_lens = torch.tensor([prefix_len], dtype=torch.int64, device=self.device)
+            prefix_lens_cpu = torch.tensor([prefix_len], dtype=torch.int64)
+            seq_lens = torch.tensor([seq_len], dtype=torch.int64, device=self.device)
+            seq_lens_cpu = torch.tensor([seq_len], dtype=torch.int64)
+            last_loc = torch.tensor([prefix_len - 1], dtype=torch.int64, device=self.device)
+
+            # Token positions for extend tokens: [20, 21, 22, ..., 119]
+            token_positions = torch.arange(prefix_len, seq_len, dtype=torch.int64, device=self.device)
+
+            initial_available = allocator.available_size()
+            indices = allocator.alloc_extend(
+                prefix_lens=prefix_lens,
+                prefix_lens_cpu=prefix_lens_cpu,
+                seq_lens=seq_lens,
+                seq_lens_cpu=seq_lens_cpu,
+                last_loc=last_loc,
+                extend_num_tokens=extend_len,
+                token_positions=token_positions,
+            )
+
+            self.assertIsNotNone(indices, f"Rank {rank} extend allocation failed")
+            self.assertEqual(len(indices), extend_len)
+
+            # Verify: Each rank should store tokens where token_idx % 4 == rank
+            expected_count = 0
+            for i, pos in enumerate(range(prefix_len, seq_len)):
+                if pos % 4 == rank:
+                    # This token belongs to current rank
+                    self.assertNotEqual(indices[i].item(), 0,
+                                      f"Rank {rank}, position {pos} should be allocated")
+                    expected_count += 1
+                else:
+                    # This token belongs to another rank
+                    self.assertEqual(indices[i].item(), 0,
+                                   f"Rank {rank}, position {pos} should be placeholder")
+
+            # Verify: All allocated indices are unique
+            allocated_indices = indices[indices > 0]
+            self.assertEqual(len(allocated_indices), expected_count)
+            self.assertEqual(len(torch.unique(allocated_indices)), expected_count,
+                           f"Rank {rank} allocated indices should be unique")
+
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
+    def test_paged_large_seq_4_ranks_decode(self, mock_rank, mock_world_size):
+        """Test PagedTokenToKVPoolAllocator.alloc_decode with DCP interleaved storage, 4 ranks, large batch."""
+        # Setup: 4 DCP ranks
+        mock_world_size.return_value = 4
+        page_size = 16
+
+        # Test each rank
+        for rank in range(4):
+            mock_rank.return_value = rank
+
+            allocator = PagedTokenToKVPoolAllocator(
+                size=1000,
+                page_size=page_size,
+                dtype=self.dtype,
+                device=self.device,
+                kvcache=self.kvcache,
+                need_sort=False,
+            )
+
+            # Large decode batch: 50 requests with varying sequence lengths
+            batch_size = 50
+            seq_lens_list = [100 + i for i in range(batch_size)]  # seq_lens: [100, 101, ..., 149]
+            seq_lens = torch.tensor(seq_lens_list, dtype=torch.int64, device=self.device)
+            seq_lens_cpu = torch.tensor(seq_lens_list, dtype=torch.int64)
+            last_loc = torch.tensor([s - 2 for s in seq_lens_list], dtype=torch.int64, device=self.device)
+
+            # Token positions: seq_len - 1 for each request
+            token_positions = (seq_lens - 1).to(torch.int64)
+
+            initial_available = allocator.available_size()
+            indices = allocator.alloc_decode(
+                seq_lens=seq_lens,
+                seq_lens_cpu=seq_lens_cpu,
+                last_loc=last_loc,
+                token_positions=token_positions,
+            )
+
+            self.assertIsNotNone(indices, f"Rank {rank} decode allocation failed")
+            self.assertEqual(len(indices), batch_size)
+
+            # Verify: Each rank should store tokens where token_idx % 4 == rank
+            expected_count = 0
+            for i, seq_len_val in enumerate(seq_lens_list):
+                token_pos = seq_len_val - 1  # Decode token position
+                if token_pos % 4 == rank:
+                    # This token belongs to current rank
+                    self.assertNotEqual(indices[i].item(), 0,
+                                      f"Rank {rank}, request {i}, position {token_pos} should be allocated")
+                    expected_count += 1
+                else:
+                    # This token belongs to another rank
+                    self.assertEqual(indices[i].item(), 0,
+                                   f"Rank {rank}, request {i}, position {token_pos} should be placeholder")
+
+            # Verify: All allocated indices are unique
+            allocated_indices = indices[indices > 0]
+            self.assertEqual(len(allocated_indices), expected_count)
+            if expected_count > 0:
+                self.assertEqual(len(torch.unique(allocated_indices)), expected_count,
+                               f"Rank {rank} allocated indices should be unique")
+
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_world_size")
+    @patch("sglang.srt.mem_cache.allocator.get_dcp_rank")
+    def test_paged_mixed_batch_4_ranks(self, mock_rank, mock_world_size):
+        """Test PagedTokenToKVPoolAllocator with mixed extend and decode, 4 ranks."""
+        # Setup: 4 DCP ranks
+        mock_world_size.return_value = 4
+        page_size = 16
+
+        # Test rank 0
+        mock_rank.return_value = 0
+
+        allocator = PagedTokenToKVPoolAllocator(
+            size=2000,
+            page_size=page_size,
+            dtype=self.dtype,
+            device=self.device,
+            kvcache=self.kvcache,
+            need_sort=False,
+        )
+
+        # First: extend with large sequence
+        prefix_len = 50
+        allocator.alloc(prefix_len)
+        seq_len = 200
+        extend_len = seq_len - prefix_len
+
+        prefix_lens = torch.tensor([prefix_len], dtype=torch.int64, device=self.device)
+        prefix_lens_cpu = torch.tensor([prefix_len], dtype=torch.int64)
+        seq_lens_extend = torch.tensor([seq_len], dtype=torch.int64, device=self.device)
+        seq_lens_cpu_extend = torch.tensor([seq_len], dtype=torch.int64)
+        last_loc_extend = torch.tensor([prefix_len - 1], dtype=torch.int64, device=self.device)
+        token_positions_extend = torch.arange(prefix_len, seq_len, dtype=torch.int64, device=self.device)
+
+        indices_extend = allocator.alloc_extend(
+            prefix_lens=prefix_lens,
+            prefix_lens_cpu=prefix_lens_cpu,
+            seq_lens=seq_lens_extend,
+            seq_lens_cpu=seq_lens_cpu_extend,
+            last_loc=last_loc_extend,
+            extend_num_tokens=extend_len,
+            token_positions=token_positions_extend,
+        )
+
+        self.assertIsNotNone(indices_extend)
+        self.assertEqual(len(indices_extend), extend_len)
+
+        # Count tokens allocated for rank 0 in extend
+        extend_rank_0_count = sum(1 for pos in range(prefix_len, seq_len) if pos % 4 == 0)
+        extend_allocated = indices_extend[indices_extend > 0]
+        self.assertEqual(len(extend_allocated), extend_rank_0_count)
+
+        # Second: decode with batch
+        batch_size = 30
+        seq_lens_decode = torch.tensor([seq_len + i for i in range(batch_size)],
+                                     dtype=torch.int64, device=self.device)
+        seq_lens_cpu_decode = seq_lens_decode.cpu()
+        last_loc_decode = torch.tensor([s - 2 for s in seq_lens_decode],
+                                      dtype=torch.int64, device=self.device)
+        token_positions_decode = (seq_lens_decode - 1).to(torch.int64)
+
+        indices_decode = allocator.alloc_decode(
+            seq_lens=seq_lens_decode,
+            seq_lens_cpu=seq_lens_cpu_decode,
+            last_loc=last_loc_decode,
+            token_positions=token_positions_decode,
+        )
+
+        self.assertIsNotNone(indices_decode)
+        self.assertEqual(len(indices_decode), batch_size)
+
+        # Count tokens allocated for rank 0 in decode
+        decode_rank_0_count = sum(1 for s in seq_lens_decode if (s - 1) % 4 == 0)
+        decode_allocated = indices_decode[indices_decode > 0]
+        self.assertEqual(len(decode_allocated), decode_rank_0_count)
+
+        # Verify: All indices are unique across extend and decode
+        all_allocated = torch.cat([extend_allocated, decode_allocated])
+        self.assertEqual(len(torch.unique(all_allocated)), len(all_allocated),
+                        "All allocated indices should be unique")
+
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/test/srt/test_dcp_interleaved_storage.py
+++ b/test/srt/test_dcp_interleaved_storage.py
@@ -401,7 +401,7 @@ class TestDCPInterleavedStorage(unittest.TestCase):
                            f"Rank {rank} should allocate {expected_count} tokens")
 
             # Verify: All allocated indices are unique
-            allocated_indices = indices[indices > 0]
+            allocated_indices = indices[indices >= 0]
             self.assertEqual(len(allocated_indices), expected_count)
             self.assertEqual(len(torch.unique(allocated_indices)), expected_count,
                            f"Rank {rank} allocated indices should be unique")
@@ -470,7 +470,7 @@ class TestDCPInterleavedStorage(unittest.TestCase):
                                    f"Rank {rank}, position {pos} should be placeholder")
 
             # Verify: All allocated indices are unique
-            allocated_indices = indices[indices > 0]
+            allocated_indices = indices[indices >= 0]
             self.assertEqual(len(allocated_indices), expected_count)
             self.assertEqual(len(torch.unique(allocated_indices)), expected_count,
                            f"Rank {rank} allocated indices should be unique")
@@ -532,7 +532,7 @@ class TestDCPInterleavedStorage(unittest.TestCase):
                                    f"Rank {rank}, request {i}, position {token_pos} should be placeholder")
 
             # Verify: All allocated indices are unique
-            allocated_indices = indices[indices > 0]
+            allocated_indices = indices[indices >= 0]
             self.assertEqual(len(allocated_indices), expected_count)
             if expected_count > 0:
                 self.assertEqual(len(torch.unique(allocated_indices)), expected_count,
@@ -586,7 +586,7 @@ class TestDCPInterleavedStorage(unittest.TestCase):
 
         # Count tokens allocated for rank 0 in extend
         extend_rank_0_count = sum(1 for pos in range(prefix_len, seq_len) if pos % 4 == 0)
-        extend_allocated = indices_extend[indices_extend > 0]
+        extend_allocated = indices_extend[indices_extend >= 0]
         self.assertEqual(len(extend_allocated), extend_rank_0_count)
 
         # Second: decode with batch
@@ -610,7 +610,7 @@ class TestDCPInterleavedStorage(unittest.TestCase):
 
         # Count tokens allocated for rank 0 in decode
         decode_rank_0_count = sum(1 for s in seq_lens_decode if (s - 1) % 4 == 0)
-        decode_allocated = indices_decode[indices_decode > 0]
+        decode_allocated = indices_decode[indices_decode >= 0]
         self.assertEqual(len(decode_allocated), decode_rank_0_count)
 
         # Verify: All indices are unique across extend and decode


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).

## Summary by Sourcery

Implement distributed cache parallel (DCP) interleaved storage for KV cache allocation across the pipeline: update alloc, alloc_extend, alloc_decode APIs to accept token_positions and distribute pages per rank; filter invalid indices in memory writes; initialize DCP state in flashmla_backend with decode enhancements; refactor attention utilities for robust streaming; and validate with extensive unit tests.

New Features:
- Add DCP interleaved storage support for KV cache allocators, distributing token slots based on token position modulo dcp_world_size and returning placeholders for non-local tokens
- Extend schedule_batch to generate token_positions during extend and decode phases to enable DCP-based allocation
- Enhance flashmla_backend decode path to initialize DCP state, enforce FP8 incompatibility, and return both attention output and log-sum-exp values

Enhancements:
- Filter out placeholder indices in memory_pool write operations to avoid overwriting in DCP mode
- Refactor attention utils: normalize tensor shapes in correct_attn_out, compute strides for non-contiguous buffers, and improve Triton kernel handling of infinite/NaN values

Tests:
- Add comprehensive test_dcp_interleaved_storage.py covering DCP interleaved allocation behavior across single-unit and paged allocators for multiple ranks and integrate it into the existing test suite