### PR TITLE
DSV4 Hopper: Support Load FP4 Models

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -227,9 +227,11 @@ class DeepseekV2MLP(nn.Module):
         prefix: str = "",
         tp_rank: Optional[int] = None,
         tp_size: Optional[int] = None,
+        swiglu_limit: Optional[float] = None,
     ) -> None:
         super().__init__()
         self.tp_size = tp_size
+        self.swiglu_limit = swiglu_limit
 
         self.gate_up_proj = MergedColumnParallelLinear(
             hidden_size,
@@ -283,6 +285,12 @@ class DeepseekV2MLP(nn.Module):
             x = (x, None, y)
 
         gate_up, _ = self.gate_up_proj(x)
+        if self.swiglu_limit is not None:
+            _g, _u = gate_up.chunk(2, dim=-1)
+            _lim = float(self.swiglu_limit)
+            gate_up = torch.cat(
+                [_g.clamp(max=_lim), _u.clamp(min=-_lim, max=_lim)], dim=-1
+            )
         x = self.act_fn(gate_up)
         x, _ = self.down_proj(
             x,
@@ -533,6 +541,7 @@ class DeepseekV2MoE(nn.Module):
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
                 reduce_results=False,
+                swiglu_limit=getattr(config, "swiglu_limit", None),
                 prefix=add_prefix("shared_experts", prefix),
                 **(
                     dict(tp_rank=0, tp_size=1)
@@ -2594,6 +2603,7 @@ class DeepseekV2DecoderLayer(nn.Module):
                 prefix=add_prefix("mlp", prefix),
                 tp_rank=mlp_tp_rank,
                 tp_size=mlp_tp_size,
+                swiglu_limit=getattr(config, "swiglu_limit", None),
             )
 
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

DeepSeek-V4-Flash ships with FP4 (E2M1) expert weights, natively supported on Blackwell (SM100) but not on Hopper (SM90, e.g. H20). Previously, loading FP4 checkpoints on Hopper would crash or produce incorrect results. This PR enables Hopper to load FP4 checkpoints by converting expert weights to FP8 at model loading time, with automatic platform-aware detection — **no manual env var overrides needed**.

## Modifications

### 1. Auto-detection with platform awareness (`model_config.py`)

When checkpoint expert dtype is `U8`/`I8`/`F4` (FP4 format):
- **Blackwell**: `FP4_EXPERTS=True, FP4_CHECKPOINT=False` — native FP4 execution
- **Hopper**: `FP4_EXPERTS=False, FP4_CHECKPOINT=True` — convert to FP8 at runtime

Both `SGLANG_DSV4_FP4_EXPERTS` and `SGLANG_DSV4_FP4_CHECKPOINT` are auto-detected and set — users **no longer need to manually set `SGLANG_DSV4_FP4_EXPERTS=0` on Hopper**.

### 2. New env var (`environ.py`)

`SGLANG_DSV4_FP4_CHECKPOINT = EnvBool(False)` — auto-set to `True` on Hopper when checkpoint expert dtype is FP4. Marks that the checkpoint is FP4 but will be converted to FP8 at runtime.

### 3. FP4→FP8 conversion (`fp8.py`)

`convert_fp4_experts_to_fp8()` — batched in-place conversion after EP/TP sharding:
- Unpack two FP4 nibbles per byte via 16-entry lookup table
- Reshape into FP8 block structure, compute per-block scale+offset
- Quantize to `float8_e4m3fn`

Weight loading: `is_fp4_expert or convert_fp4_to_fp8` shares FP4 loading logic (same on-disk format). In `process_weights_after_loading`, conversion runs on w13/w2 then returns early.

### 4. Simplified `_dequant_fp8_wo_a()` (`deepseek_v4.py`)

Removed `SGLANG_FIX_DSV4_BASE_MODEL_LOAD` and legacy code paths. Now always dequantizes FP8 `wo_a` weights with streaming yield. Added `ValueError` for missing scales.

## Accuracy Tests

**Environment**: 8× H20-3e (SM90), SGLang 0.5.10rc0, GSM8K 8-shot

### Startup Command

CP8 deepep:

```bash
export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0

nohup python3 -m sglang.launch_server --model-path $model_path \
  --host 0.0.0.0 --port 8188 --trust-remote-code \
  --enable-cache-report --log-level info --max-running-requests 128 \
  --tp-size 8 --cuda-graph-max-bs 128 \
  --mem-fraction-static 0.80 \
  --enable-nsa-prefill-context-parallel --nsa-prefill-cp-mode round-robin-split \
  --tool-call-parser deepseekv4 \
  --reasoning-parser deepseek-v4 \
  --speculative-algo EAGLE \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --moe-a2a-backend deepep \
  > /home/admin/logs/sglang.log 2>&1 &
```

Model paths: `/home/models/DeepSeek-V4-Flash` (FP4), `/home/models/DeepSeek-V4-Flash-FP8` (FP8).

### GSM8K Evaluation

```bash
python -m sglang.test.run_eval --eval-name gsm8k --host localhost --port 8188 --num-shots 8
```

### Auto-detection

| Model | Detected dtype | FP4_EXPERTS | FP4_CHECKPOINT |
|-------|---------------|-------------|----------------|
| Base | F8_E4M3 | False | False |
| FP4 | I8 | False | True |
| FP8 | F8_E4M3 | False | False |

### Results

| Model | SGLANG_DSV4_FP4_EXPERTS | GSM8K 8-shot |
|-------|------------------------|-------------|
| FP4 (auto-detect, no env var) | not set | **97.2%** |
| FP4 (with env var) | =0 | **96.9%** |
| FP8 | not set | **97.0%** |
| FP8 | =0 | **96.9%** |

FP4→FP8 conversion matches native FP8 accuracy (within noise). Auto-detection works correctly — no manual env var needed.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
