### PR TITLE
fix(pp): idle-batch prefill lockstep + need_topk None-topk_p guard for PP+MTP+dp-attn

### DIFF
--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -302,7 +302,11 @@ class FutureMap:
 
         # Spec extras are gated by spec_algo, not by the payload's shape, so a
         # non-spec stash allocates no extra bufs (only output_tokens_buf).
-        self.need_topk = self.spec_algo.is_some() and self.spec_algo.need_topk()
+        self.need_topk = (
+            self.spec_algo.is_some()
+            and self.spec_algo.need_topk()
+            and payload.topk_p is not None
+        )
         self.need_hidden_states = (
             self.spec_algo.is_some()
             and spec_need_hidden_states()

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1192,7 +1192,21 @@ class EAGLEWorkerV2(BaseSpecWorker):
         grammar_barrier=None,
         pp_proxy_tensors=None,
     ):
-        if batch.forward_mode.is_extend():
+        # Under PP + DP attention, a rank with no local requests must still run
+        # in lockstep with the DP peers that are prefilling. On a global prefill
+        # step (some peer is extending, so the dp-attn all-gather sets
+        # is_extend_in_batch) the idle batch has to follow the *prefill* path so
+        # every DP rank emits the same MoE cross-DP collective sequence (target
+        # forward + a single draft_extend). Falling into the verify path below
+        # would add speculative_num_steps extra draft-decode collectives on the
+        # idle rank and desync the MoE all-gather -> hang. _draft_extend_for_prefill
+        # already short-circuits its input_ids build for idle batches.
+        run_as_prefill = batch.forward_mode.is_extend() or (
+            self._pp_enabled
+            and batch.forward_mode.is_idle()
+            and batch.is_extend_in_batch
+        )
+        if run_as_prefill:
             # Target prefill. Only the last PP rank needs to capture hidden
             # states for the draft; non-last ranks relay upstream without capture.
             if not self._pp_enabled or self._pp_is_last_rank:


### PR DESCRIPTION
Two fixes on top of the PP+MTP branch, both required to run EAGLE/MTP spec under pp+dp-attn (validated on 2-node tp8/pp2/dp8 GLM5.2)


1. **Idle-batch prefill lockstep** (eagle_worker_v2.py)
   Under PP + DP attention, an idle rank on a global prefill step was routed
   to the verify path, emitting `speculative_num_steps` extra draft-decode
   collectives that desync the MoE cross-DP all-gather → hang. Now gated on
   `is_extend or (pp_enabled and idle and is_extend_in_batch)`, mirroring the
   scheduler's is_extend_in_batch lockstep. `_draft_extend_for_prefill` already
   short-circuits idle batches, so the collective sequence stays identical
   across DP ranks. Root-caused via py-spy on the collective barrier.

2. **need_topk None-topk_p guard** (overlap_utils.py)
   `need_topk` gated only on spec_algo took the topk stash path even when the
   payload had no topk_p, crashing at `payload.topk_p[0]`. Added the
   `payload.topk_p is not None` guard, matching the existing
   `payload.hidden_states` check.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #30099974496](https://github.com/antgroup/sglang/actions/runs/30099974496)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #30099974262](https://github.com/antgroup/sglang/actions/runs/30099974262)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->