### PR TITLE
fix(pp): generate MTP draft tree after prefill

### DIFF
--- a/python/sglang/srt/distributed/bootstrap.py
+++ b/python/sglang/srt/distributed/bootstrap.py
@@ -105,11 +105,17 @@ def init_torch_distributed(
                 tp_size=ps.tp_size, pp_size=ps.pp_size, moe_ep_size=ps.moe_ep_size
             )
 
+    # When pipeline parallelism is enabled, the draft model should use the TP
+    # communication group of its PP rank rather than the world group.
+    if is_draft_worker and ps.pp_size > 1:
+        sync_group = get_tp_group()
+    else:
+        sync_group = get_world_group()
     pre_model_load_memory = get_available_gpu_memory(
         device,
         ps.gpu_id,
-        distributed=get_world_group().world_size > 1,
-        cpu_group=get_world_group().cpu_group,
+        distributed=sync_group.world_size > 1,
+        cpu_group=sync_group.cpu_group,
     )
     tp_group = get_tp_group()
     pp_group = get_pp_group()

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -302,7 +302,11 @@ class FutureMap:
 
         # Spec extras are gated by spec_algo, not by the payload's shape, so a
         # non-spec stash allocates no extra bufs (only output_tokens_buf).
-        self.need_topk = self.spec_algo.is_some() and self.spec_algo.need_topk()
+        self.need_topk = (
+            self.spec_algo.is_some()
+            and self.spec_algo.need_topk()
+            and payload.topk_p is not None
+        )
         self.need_hidden_states = (
             self.spec_algo.is_some()
             and spec_need_hidden_states()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1067,6 +1067,13 @@ class Scheduler(
             self.chunked_prefill_size is not None
             and self.server_args.enable_mixed_chunk
         )
+        # Under PP + spec, prefill reqs run as EXTEND and decode reqs as
+        # TARGET_VERIFY, so they cannot be merged into a single MIXED batch.
+        assert not (
+            self.is_mixed_chunk
+            and self.ps.pp_size > 1
+            and not self.spec_algorithm.is_none()
+        ), "PP + spec-v2 does not support mixed-chunk prefill; disable --enable-mixed-chunk."
 
         # Init the dynamic chunking predictor for PP
         self.enable_dynamic_chunking = (
@@ -1189,9 +1196,13 @@ class Scheduler(
             server_args=self.server_args,
         )
 
-        if self.spec_algorithm.carries_draft_hidden_states():
+        if (
+            self.spec_algorithm.carries_draft_hidden_states()
+            and self.draft_worker.draft_worker is not None
+        ):
             # `draft_runner` aliases `draft_runner_list[0]` in the multi-layer
-            # worker, so a single accessor covers both shapes.
+            # worker, so a single accessor covers both shapes. Non-last PP
+            # ranks have no draft worker, so fall through to the default.
             draft_runner = self.draft_worker.draft_worker.draft_runner
             disagg_hidden_size, disagg_hidden_states_dtype = (
                 get_draft_recurrent_hidden_state_spec(draft_runner)
@@ -3497,6 +3508,18 @@ class Scheduler(
                 batch_result = self.tp_worker.forward_batch_split_prefill(batch)
                 self._relay_forward_payload(batch.req_pool_indices, batch_result)
                 batch.input_ids = None
+            elif not batch.spec_algorithm.is_none() and self.ps.pp_size > 1:
+                # PP + spec non-overlap path: forward receives pp_proxy_tensors
+                # and returns batch_result whose post-processing (KV move,
+                # seq_lens advance) is handled by process_batch_result on every
+                # PP rank. Non-last ranks get EaglePPVerifyInputRaw via spec_info
+                # from _pp_prep_batch_result.
+                resolve_forward_inputs(batch, self.future_map)
+                with self._forward_isolation(batch, overlap=False):
+                    batch_result = self.model_worker.forward_batch_generation(
+                        batch, pp_proxy_tensors=pp_proxy_tensors
+                    )
+                self.update_cache_from_scheduler(batch, batch_result)
             elif not batch.spec_algorithm.is_none():
                 # Non-overlap: drive the V2 worker synchronously (no
                 # future_map relay / on_publish).

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -29,6 +29,8 @@ from sglang.srt.mem_cache.common import (
 )
 from sglang.srt.runtime_context import get_server_args
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
+from sglang.srt.speculative.eagle_info import EaglePPVerifyInputRaw
+from sglang.srt.speculative.spec_utils import move_accept_tokens_to_target_kvcache
 from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
 from sglang.srt.state_capturer.routed_experts import get_global_experts_capturer
 
@@ -761,6 +763,25 @@ class SchedulerBatchResultProcessor:
                 value=can_run_cuda_graph
             )
 
+        accept_lens = None
+        accept_lens_cpu = None
+        if isinstance(batch.spec_info, EaglePPVerifyInputRaw):
+            pp_raw = batch.spec_info
+            accept_lens_cpu = torch.tensor(pp_raw.accept_lens, dtype=torch.int64)
+            accept_lens = accept_lens_cpu.to(batch.seq_lens.device)
+            if pp_raw.accept_index is not None:
+                accept_index = torch.tensor(
+                    pp_raw.accept_index,
+                    dtype=torch.long,
+                    device=batch.seq_lens.device,
+                )
+                move_accept_tokens_to_target_kvcache(
+                    batch,
+                    accept_index,
+                    accept_lens - 1,
+                    self.model_worker.token_to_kv_pool_allocator,
+                )
+
         self.token_to_kv_pool_allocator.free_group_begin()
 
         for i, req in enumerate(batch.reqs):
@@ -823,6 +844,12 @@ class SchedulerBatchResultProcessor:
 
         self.output_streamer.stream_output(batch.reqs, batch.return_logprob)
         self.token_to_kv_pool_allocator.free_group_end()
+
+        if isinstance(batch.spec_info, EaglePPVerifyInputRaw):
+            batch.seq_lens = batch.seq_lens + accept_lens
+            if batch.seq_lens_cpu is not None:
+                batch.seq_lens_cpu = batch.seq_lens_cpu + accept_lens_cpu
+            batch.seq_lens_sum = None
 
         self.metrics_reporter.forward_ct_decode = (
             self.metrics_reporter.forward_ct_decode + 1

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -1011,6 +1011,13 @@ class SchedulerPPMixin:
                 **tensor_dict,
                 **logprob_dict,
             }
+
+        # PP + spec: the last PP rank serializes the draft tree so non-last ranks
+        # can rebuild EagleVerifyInput on the next iter. Carried as plain Python
+        # lists alongside the tensor payload.
+        if result.pp_verify_input_raw:
+            tensor_dict.update(result.pp_verify_input_raw.to_tensor_dict())
+
         return tensor_dict
 
     def _pp_send_dict_to_next_stage(
@@ -1124,6 +1131,7 @@ class SchedulerPPMixin:
         pp_outputs: PPProxyTensors,
     ):
         from sglang.srt.managers.scheduler import GenerationBatchResult
+        from sglang.srt.speculative.eagle_info import EaglePPVerifyInputRaw
 
         logits_output = None
         extend_input_len_per_req = None
@@ -1136,13 +1144,35 @@ class SchedulerPPMixin:
                 extend_logprob_start_len_per_req,
             ) = get_logprob_from_pp_outputs(pp_outputs)
         next_token_ids = pp_outputs["next_token_ids"].to(torch.int64)
-        # PP rank 0 also relays into output_tokens_buf so the next iter's
-        # resolve_forward_inputs finds these tokens for the decode portion
-        # of mixed-chunk batches (which gather via mix_running_indices).
-        self.future_map.stash(
-            batch.req_pool_indices, RelayPayload(bonus_tokens=next_token_ids)
-        )
-        batch.input_ids = None
+        batch.input_ids = next_token_ids
+
+        if not self.spec_algorithm.is_none() and "pp_spec_output" in pp_outputs.tensors:
+            # Spec-v2 decode path: the last PP rank produced draft tokens for
+            # this iter; rebuild the raw draft tree so _build_verify_input_from_pp_raw
+            # can construct EagleVerifyInput on this rank.
+            batch.spec_info = EaglePPVerifyInputRaw.from_pp_outputs(pp_outputs)
+        elif not self.spec_algorithm.is_none() and batch.forward_mode.is_extend():
+            if batch.contains_last_prefill_chunk:
+                # The last PP rank produces no draft tokens for prefill batches;
+                # build a dummy draft for the first decode step.
+                batch.spec_info = EaglePPVerifyInputRaw.build_dummy_for_decode(
+                    batch, self.server_args.speculative_num_draft_tokens
+                )
+            else:
+                # Chunked prefill middle chunk: its next_token_ids is a
+                # placeholder that no consumer reads (the next iter is another
+                # extend and resolve_forward_inputs sources input_ids from the
+                # prefill staging copy). Do nothing here.
+                pass
+        else:
+            # PP rank 0 also relays into output_tokens_buf so the next iter's
+            # resolve_forward_inputs finds these tokens for the decode portion
+            # of mixed-chunk batches (which gather via mix_running_indices).
+            self.future_map.stash(
+                batch.req_pool_indices, RelayPayload(bonus_tokens=next_token_ids)
+            )
+            batch.input_ids = None
+
         output_result = GenerationBatchResult(
             logits_output=logits_output,
             pp_hidden_states_proxy_tensors=None,
@@ -1151,6 +1181,23 @@ class SchedulerPPMixin:
             extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
             can_run_cuda_graph=mb_metadata.can_run_cuda_graph,
         )
+
+        if isinstance(batch.spec_info, EaglePPVerifyInputRaw):
+            output_result.accept_lens = torch.tensor(
+                batch.spec_info.accept_lens, dtype=torch.int64
+            )
+            output_result.speculative_num_draft_tokens = (
+                self.server_args.speculative_num_draft_tokens
+            )
+
+        # Async copy the CPU-bound fields ahead of time; d2h_event in the
+        # caller guarantees completion before the result is consumed.
+        output_result.copy_done = self.device_module.Event()
+        output_result.copy_to_cpu(
+            return_logprob=batch.return_logprob,
+            return_hidden_states=False,
+        )
+
         return output_result
 
     def _pp_process_batch_result(

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -1153,8 +1153,12 @@ class SchedulerPPMixin:
             batch.spec_info = EaglePPVerifyInputRaw.from_pp_outputs(pp_outputs)
         elif not self.spec_algorithm.is_none() and batch.forward_mode.is_extend():
             if batch.contains_last_prefill_chunk:
-                # The last PP rank produces no draft tokens for prefill batches;
-                # build a dummy draft for the first decode step.
+                if not self.enable_dp_attention:
+                    raise RuntimeError(
+                        "Final PP speculative prefill output is missing its draft tree"
+                    )
+                # DP attention still uses a synchronized dummy bootstrap because
+                # all peers must agree on the final prefill chunk.
                 batch.spec_info = EaglePPVerifyInputRaw.build_dummy_for_decode(
                     batch, self.server_args.speculative_num_draft_tokens
                 )

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -288,6 +288,7 @@ class TpModelWorker(BaseTpWorker):
         memory_pool_config: Optional[MemoryPoolConfig] = None,
         is_multi_layer_eagle: bool = False,
         context_length: Optional[int] = None,
+        pp_global_random_seed: Optional[int] = None,
     ):
         # Parse args
         self.server_args = server_args
@@ -345,8 +346,16 @@ class TpModelWorker(BaseTpWorker):
         self.world_group = get_world_group()
 
         # Sync random seed across TP workers.
+        # Under PP the draft worker's TP worker is created on only one PP rank
+        # (the last), so it cannot join the launch-time WORLD broadcast; reuse
+        # the target worker's resolved seed directly.
         # Elastic joiners cannot enter the launch-time WORLD broadcast.
-        if server_args.is_ep_joiner:
+        if self.is_draft_worker and server_args.pp_size > 1:
+            assert (
+                pp_global_random_seed is not None
+            ), "pp_global_random_seed must be provided for the draft worker under PP"
+            self.random_seed = pp_global_random_seed
+        elif server_args.is_ep_joiner:
             self.random_seed = server_args.random_seed
         else:
             self.random_seed = broadcast_pyobj(

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -15,8 +15,10 @@ from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
 from sglang.srt.state_capturer.base import TopkCaptureOutput
 
 if TYPE_CHECKING:
-    from sglang.srt.managers.scheduler import GenerationBatchResult
-    from sglang.srt.speculative.eagle_info import EagleDraftInput
+    from sglang.srt.speculative.eagle_info import (
+        EagleDraftInput,
+        EaglePPVerifyInputRaw,
+    )
 
 
 logger = logging.getLogger(__name__)
@@ -76,6 +78,7 @@ class GenerationBatchResult:
     # FIXME(lsyin): maybe move to a better place?
     # sync path: forward stream -> output processor
     accept_lens: Optional[torch.Tensor] = None
+    accept_index: Optional[torch.Tensor] = None
 
     block_accept_lens: Optional[torch.Tensor] = None
 
@@ -102,6 +105,11 @@ class GenerationBatchResult:
     # Forward pass metrics (FPM) — GPU-accurate timing via CUDA events
     fpm_start_event: Optional[torch.cuda.Event] = None
     fpm_end_event: Optional[torch.cuda.Event] = None
+
+    # PP + Spec: produced by the last PP rank after draft/draft_extend_for_decode,
+    # consumed by _pp_prepare_tensor_dict for PP ring transmission so non-last PP
+    # ranks can rebuild EagleVerifyInput on the next iteration.
+    pp_verify_input_raw: Optional[EaglePPVerifyInputRaw] = None
 
     @property
     def has_sampled_token_ids(self) -> bool:

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -62,6 +62,12 @@ def get_draft_kv_pool(
     if draft_worker is None or spec_algorithm.is_ngram():
         return None
 
+    # Under PP the draft model only runs on its host PP rank (the last one);
+    # other ranks have no draft worker and thus no draft KV pool.
+    parallel = get_parallel()
+    if parallel.pp_size > 1 and parallel.pp_rank != parallel.pp_size - 1:
+        return None
+
     # V2 workers nest the draft runner under `.draft_worker`.
     if server_args.enable_multi_layer_eagle:
         draft_runner = draft_worker.draft_worker.draft_runner_list[0]

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -387,7 +387,7 @@ class ModelRunner:
             "pp_proxy_tensors" in inspect.signature(self.model.forward).parameters
         )
 
-        if self.ps.pp_size > 1:
+        if self.ps.pp_size > 1 and not self.is_draft_worker:
             assert (
                 self.support_pp
             ), "Pipeline Parallel is not compatible with this model."

--- a/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
@@ -193,14 +193,19 @@ def _assert_pp_mtp_compat(
     num_effective_layers: int,
     model_num_layers: int,
 ) -> None:
+    # PP partitions layers across ranks, so each rank holds only a slice
+    # (num_effective_layers < model_num_layers). PP+EAGLE and PP+DSpark
+    # explicitly support MTP draft models on the last PP rank, so the
+    # per-rank slice must not trigger the "PP incompatible with MTP" guard.
     assert (
         (not model_has_mtp_layers)
         or (spec_algorithm.is_none())
+        or (num_effective_layers == model_num_layers)
         or (
-            (not spec_algorithm.is_none())
-            and (num_effective_layers == model_num_layers)
+            (num_effective_layers != model_num_layers)
+            and (spec_algorithm.is_eagle() or spec_algorithm.is_dspark())
         )
-    ), "PP is not compatible with MTP models."
+    ), "PP is not compatible with MTP models except when using EAGLE or DSpark speculative decoding."
 
 
 def adjust_hybrid_swa_layer_ids(

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -143,41 +143,45 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
             else kvc.server_args.max_total_tokens or kvc.model_config.context_len
         )
 
-        # EAGLE/STANDALONE: scale cell_size to account for draft model KV cache.
-        # Assumes draft and target share the same per-layer KV size (head_dim,
-        # num_kv_heads, dtype), which holds for EAGLE/MTP draft models that
-        # reuse the target architecture's attention config.
-        if (
-            kvc.spec_algorithm.is_eagle() or kvc.spec_algorithm.is_standalone()
-        ) and not kvc.is_draft_worker:
-            eagle_draft_num_layers = kvc.spec_aux_config.eagle_draft_num_layers
+        # Under pipeline parallelism the draft worker lives on a single PP rank
+        # (the last one); only that rank's target pool needs to reserve draft
+        # KV. Matches DSV4PoolConfigurator's (pp_size==1 or is_last_rank).
+        if kvc.ps.pp_size == 1 or kvc.pp_group.is_last_rank:
+            # EAGLE/STANDALONE: scale cell_size to account for draft model KV cache.
+            # Assumes draft and target share the same per-layer KV size (head_dim,
+            # num_kv_heads, dtype), which holds for EAGLE/MTP draft models that
+            # reuse the target architecture's attention config.
             if (
-                eagle_draft_num_layers is not None
-                and int(eagle_draft_num_layers) > 0
-                and int(num_layers) > 0
-            ):
-                self._cell_size = int(
-                    self._cell_size
-                    * (1 + int(eagle_draft_num_layers) / int(num_layers))
+                kvc.spec_algorithm.is_eagle() or kvc.spec_algorithm.is_standalone()
+            ) and not kvc.is_draft_worker:
+                eagle_draft_num_layers = kvc.spec_aux_config.eagle_draft_num_layers
+                if (
+                    eagle_draft_num_layers is not None
+                    and int(eagle_draft_num_layers) > 0
+                    and int(num_layers) > 0
+                ):
+                    self._cell_size = int(
+                        self._cell_size
+                        * (1 + int(eagle_draft_num_layers) / int(num_layers))
+                    )
+
+            # DFLASH/DSPARK: scale cell_size to account for draft model KV cache
+            if kvc.spec_algorithm.is_dflash_family() and not kvc.is_draft_worker:
+                from sglang.srt.speculative.dflash_utils import (
+                    scale_kv_cell_size_per_token_for_dflash,
                 )
 
-        # DFLASH/DSPARK: scale cell_size to account for draft model KV cache
-        if kvc.spec_algorithm.is_dflash_family() and not kvc.is_draft_worker:
-            from sglang.srt.speculative.dflash_utils import (
-                scale_kv_cell_size_per_token_for_dflash,
-            )
-
-            draft_num_layers = kvc.spec_aux_config.dflash_draft_num_layers
-            if (
-                draft_num_layers is not None
-                and int(draft_num_layers) > 0
-                and int(num_layers) > 0
-            ):
-                self._cell_size = scale_kv_cell_size_per_token_for_dflash(
-                    target_cell_size_per_token=self._cell_size,
-                    target_num_layers=int(num_layers),
-                    draft_num_layers=int(draft_num_layers),
-                )
+                draft_num_layers = kvc.spec_aux_config.dflash_draft_num_layers
+                if (
+                    draft_num_layers is not None
+                    and int(draft_num_layers) > 0
+                    and int(num_layers) > 0
+                ):
+                    self._cell_size = scale_kv_cell_size_per_token_for_dflash(
+                        target_cell_size_per_token=self._cell_size,
+                        target_num_layers=int(num_layers),
+                        draft_num_layers=int(draft_num_layers),
+                    )
 
     def _compute_cell_size(self, kvc: KVCacheConfigurator, num_layers: int) -> int:
         """Compute per-token KV cache cost in bytes. Subclasses can override."""
@@ -663,11 +667,13 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.num_layers_ca128 = sum(1 for r in self.compression_ratios if r == 128)
 
         self.bytes_per_full_token = self._get_bytes_per_full_token()
-        if self.is_speculative:
+        if self.is_speculative and (kvc.ps.pp_size == 1 or kvc.pp_group.is_last_rank):
             # Reserve memory for the speculative draft worker by inflating
             # per-token bytes by (target+draft)/target. Equivalent to dflash's
             # scale_kv_cell_size_per_token_for_dflash but applied to
             # bytes_per_full_token: tokens = avail / (bpft * (T+D)/T).
+            # Under pipeline parallelism, only the draft-host PP rank (the last one)
+            # needs this: the draft model's KV pool lives only there.
             draft_layers = 1
             target_layers = self.num_layers_total
             self.bytes_per_full_token *= (target_layers + draft_layers) / target_layers

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -1095,6 +1095,15 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 self.buffers.input_embeds[: self.raw_num_token].copy_(
                     forward_batch.input_embeds
                 )
+            # Under speculative decoding + PP, pp_proxy_tensors also
+            # need to be copied here
+            if pp_proxy_tensors is not None and hasattr(
+                self.buffers, "pp_proxy_tensors"
+            ):
+                for key, dst in self.buffers.pp_proxy_tensors.items():
+                    src = pp_proxy_tensors.tensors.get(key)
+                    if src is not None:
+                        dst[: src.shape[0]].copy_(src)
             variant_label = self._resolve_lora_variant(forward_batch)
             stream_idx = get_current_stream_idx() if self.enable_pdmux else None
             self._replay_graph_key = self._make_graph_key(
@@ -1288,7 +1297,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             )
         else:
             assert isinstance(output, PPProxyTensors)
-            return PPProxyTensors({k: v[: self.bs] for k, v in output.tensors.items()})
+            return PPProxyTensors(
+                {k: v[: self.raw_num_token] for k, v in output.tensors.items()}
+            )
 
     def get_spec_info(self, num_tokens: int):
         spec_info = None

--- a/python/sglang/srt/model_executor/runner_utils/buffers.py
+++ b/python/sglang/srt/model_executor/runner_utils/buffers.py
@@ -132,11 +132,11 @@ class DecodeInputBuffers(ForwardInputBuffers):
                 is_mhc = hc_hidden_size is not None
                 hs = hc_hidden_size if is_mhc else hidden_size
                 pp_proxy_tensors = {
-                    "hidden_states": torch.zeros((max_bs, hs), dtype=dtype),
+                    "hidden_states": torch.zeros((max_num_token, hs), dtype=dtype),
                 }
                 if not is_mhc:
                     pp_proxy_tensors["residual"] = torch.zeros(
-                        (max_bs, hidden_size), dtype=dtype
+                        (max_num_token, hidden_size), dtype=dtype
                     )
                 if pp_proxy_topk_size is not None:
                     pp_proxy_tensors["topk_indices"] = torch.zeros(

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -230,11 +230,20 @@ class DeepseekV2WeightLoaderMixin:
                         nextn_layer_prefix=layer_prefix,
                         nextn_spec_weight_names=spec_weight_names,
                     ):
-                        if not name.startswith(layer_prefix):
+                        # lm_head is always shared from the target model.
+                        if "shared_head.head" in name:
                             continue
 
-                        # Use shared head and embed weights from target model
-                        if "shared_head.head" in name or "embed_tokens" in name:
+                        # Under PP the draft model loads its own embed_tokens on
+                        # the last rank; otherwise embed is shared from target.
+                        is_embed = "embed_tokens" in name
+                        if is_embed and (
+                            self.pp_group.world_size == 1
+                            or not self.pp_group.is_last_rank
+                        ):
+                            continue
+
+                        if not name.startswith(layer_prefix) and not is_embed:
                             continue
 
                         # Transform name: NextN-specific → "model.*", decoder → "model.decoder.*"
@@ -330,8 +339,14 @@ class DeepseekV2WeightLoaderMixin:
                         # Skip loading extra bias for GPTQ models.
                         if name.endswith(".bias") and name not in params_dict:
                             continue
-                        # Skip loading embed_tokens if not first rank in pipeline parallelism
-                        if ".embed_tokens." in name and not self.pp_group.is_first_rank:
+                        # Skip loading embed_tokens if not first rank in pipeline parallelism.
+                        # For the nextn draft, embed_tokens is already handled above (loaded
+                        # on the last rank under PP), so do not skip it here.
+                        if (
+                            ".embed_tokens." in name
+                            and not is_nextn
+                            and not self.pp_group.is_first_rank
+                        ):
                             continue
                         # Skip loading norm if not last rank in pipeline parallelism
                         if ".norm." in name and not self.pp_group.is_last_rank:
@@ -468,6 +483,7 @@ class DeepseekV2WeightLoaderMixin:
                 "eh_proj",
                 "enorm",
                 "hnorm",
+                "embed_tokens",
             ],
         )
 

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -225,16 +225,24 @@ class DeepseekModelNextN(nn.Module):
             else:
                 hidden_states = input_embeds
 
+            # CP-v2 shards/gathers at the eager-runner boundary instead.
+            spec_hidden = forward_batch.spec_info.hidden_states
+            use_cp_v1 = (
+                dsa_use_prefill_cp(forward_batch, self.dsa_enable_prefill_cp)
+                or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp)
+            ) and not is_cp_v2_active(forward_batch)
+            if use_cp_v1:
+                hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
+                positions = cp_split_and_rebuild_position(forward_batch, positions)
+                spec_hidden = cp_split_and_rebuild_data(forward_batch, spec_hidden)
+
             if hidden_states.shape[0] > 0:
-                previous_hidden_states = forward_batch.spec_info.hidden_states
                 if self.rot_weight is not None:
-                    previous_hidden_states = torch.matmul(
-                        previous_hidden_states, self.rot_weight
-                    )
+                    spec_hidden = torch.matmul(spec_hidden, self.rot_weight)
                 if _is_cuda:
                     eh_input = fused_eh_norm(
                         hidden_states,
-                        previous_hidden_states,
+                        spec_hidden,
                         self.enorm.weight,
                         self.hnorm.weight,
                         self.enorm.variance_epsilon,
@@ -243,7 +251,7 @@ class DeepseekModelNextN(nn.Module):
                     eh_input = torch.cat(
                         (
                             self.enorm(hidden_states),
-                            self.hnorm(previous_hidden_states),
+                            self.hnorm(spec_hidden),
                         ),
                         dim=-1,
                     )
@@ -252,14 +260,6 @@ class DeepseekModelNextN(nn.Module):
                 else:
                     hidden_states = self.eh_proj(eh_input)
 
-            # CP-v2 shards/gathers at the eager-runner boundary instead.
-            use_cp_v1 = (
-                dsa_use_prefill_cp(forward_batch, self.dsa_enable_prefill_cp)
-                or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp)
-            ) and not is_cp_v2_active(forward_batch)
-            if use_cp_v1:
-                hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
-                positions = cp_split_and_rebuild_position(forward_batch, positions)
             residual = None
             seed_buf = (
                 forward_batch.spec_info.dsa_seed_topk_capture

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2941,6 +2941,9 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
+    def get_head(self):
+        return self.lm_head.weight
+
     def set_embed_and_head(self, embed, head):
         del self.model.embed_tokens.weight
         del self.lm_head.weight
@@ -2948,6 +2951,12 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         self.lm_head.weight = head
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
+
+    def set_head(self, head):
+        del self.lm_head.weight
+        self.lm_head.weight = head
+        torch.get_device_module().empty_cache()
+        torch.get_device_module().synchronize()
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2925,10 +2925,18 @@ class DeepseekV4ForCausalLM(nn.Module):
                             if name.startswith("mtp"):
                                 continue
                     else:
-                        if "shared_head.head" in name or "embed_tokens" in name:
+                        if "shared_head.head" in name:
+                            continue
+                        is_embed = "embed_tokens" in name
+                        # Under PP the draft model loads its own embed_tokens on
+                        # the last rank; otherwise embed is shared from target.
+                        if is_embed and (
+                            self.pp_group.world_size == 1
+                            or not self.pp_group.is_last_rank
+                        ):
                             continue
 
-                        if not name.startswith(nextn_layer_prefix):
+                        if not name.startswith(nextn_layer_prefix) and not is_embed:
                             continue
 
                         in_decoder = True
@@ -3004,6 +3012,7 @@ class DeepseekV4ForCausalLM(nn.Module):
                                 continue
                             if (
                                 ".embed_tokens." in name
+                                and not is_nextn
                                 and not self.pp_group.is_first_rank
                             ):
                                 continue
@@ -3129,7 +3138,11 @@ class DeepseekV4ForCausalLM(nn.Module):
             skipped_checking_patterns.append("model.norm.")
             skipped_checking_patterns.extend(["lm_head", "hc_head_"])
         if is_nextn:
-            skipped_checking_patterns.extend(["lm_head", "embed_tokens"])
+            skipped_checking_patterns.extend(["lm_head"])
+            # Under PP the draft loads embed_tokens itself, so do not skip it here;
+            # under non-PP it is still shared from target by eagle_worker, so skip it.
+            if self.pp_group.world_size == 1:
+                skipped_checking_patterns.extend(["embed_tokens"])
         unloaded_params = {
             p
             for p in unloaded_params
@@ -3151,6 +3164,9 @@ class DeepseekV4ForCausalLM(nn.Module):
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
+    def get_head(self):
+        return self.lm_head.weight
+
     def set_embed_and_head(self, embed, head):
         del self.model.embed_tokens.weight
         del self.lm_head.weight
@@ -3158,6 +3174,12 @@ class DeepseekV4ForCausalLM(nn.Module):
         self.lm_head.weight = head
         # Hot weight reload (RL workflows). Use the device-agnostic module
         # accessor so this works on both CUDA/HIP and NPU.
+        torch.get_device_module().empty_cache()
+        torch.get_device_module().synchronize()
+
+    def set_head(self, head):
+        del self.lm_head.weight
+        self.lm_head.weight = head
         torch.get_device_module().empty_cache()
         torch.get_device_module().synchronize()
 

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -15,6 +15,7 @@ from sglang.srt.layers.attention.dsa.utils import (
 )
 from sglang.srt.layers.dp_attention import (
     dp_gather_partial,
+    get_attention_dp_size,
     get_global_dp_buffer_len,
     is_dp_attention_enabled,
 )
@@ -142,12 +143,22 @@ class DeepseekV4ModelNextN(nn.Module):
         else:
             hidden_states = input_embeds
 
+        spec_hidden = forward_batch.spec_info.hidden_states
+
+        if dsa_use_prefill_cp(forward_batch):
+            assert get_attention_dp_size() == 1
+            hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
+            positions = cp_split_and_rebuild_position(forward_batch, positions)
+            input_ids = cp_round_robin_input_ids(input_ids)
+            spec_hidden = cp_split_and_rebuild_data(
+                forward_batch,
+                spec_hidden.view(-1, self.hc_mult, self.config.hidden_size),
+            )
+
         if hidden_states.shape[0] > 0:
             n_tokens = hidden_states.shape[0]
             d = self.config.hidden_size
-            hc_flat = forward_batch.spec_info.hidden_states.view(
-                n_tokens * self.hc_mult, d
-            )
+            hc_flat = spec_hidden.view(n_tokens * self.hc_mult, d)
             h_proj_out, _ = self.h_proj(self.hnorm(hc_flat))
             h_proj_hidden_states = h_proj_out.view(n_tokens, self.hc_mult, d)
 
@@ -165,12 +176,6 @@ class DeepseekV4ModelNextN(nn.Module):
             dp_gather_partial(input_ids_global, input_ids[:, None], forward_batch)
             input_ids_global = input_ids_global.squeeze(-1)
         else:
-            input_ids_global = input_ids
-
-        if dsa_use_prefill_cp(forward_batch):
-            hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
-            positions = cp_split_and_rebuild_position(forward_batch, positions)
-            input_ids = cp_round_robin_input_ids(input_ids)
             input_ids_global = input_ids
 
         hidden_states, residual, post, comb = self.decoder(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -8344,8 +8344,8 @@ class ServerArgs:
 
         if self.pp_size > 1:
             assert (
-                self.disable_overlap_schedule and self.speculative_algorithm is None
-            ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
+                self.disable_overlap_schedule
+            ), "Pipeline parallelism is not compatible with overlap schedule"
 
         assert not (
             self.dp_size > 1 and self.nnodes != 1 and not self.enable_dp_attention

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -84,6 +84,13 @@ def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
             "enable_pdmux=True is not supported "
             "(adaptive state swap does not update decode_attn_backend_group)"
         )
+    if server_args.pp_size > 1:
+        return (
+            "pipeline_parallel_size>1 is not supported "
+            "(adaptive state switching only happens on the last PP rank; "
+            "an extra synchronization mechanism would be needed to keep all "
+            "PP ranks in sync)"
+        )
     return None
 
 

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -1,10 +1,11 @@
 import logging
-from dataclasses import dataclass
-from typing import List, Optional
+from dataclasses import asdict, dataclass
+from typing import List, Optional, Tuple
 
 import torch
 
 from sglang.kernels.ops.attention.utils import create_flashinfer_kv_indices_triton
+from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 from sglang.srt.runtime_context import get_server_args
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
@@ -387,3 +388,107 @@ class EagleDraftExtendInput(SpecInput):
             req_to_token.size(1),
         )
         return kv_indices, cum_kv_seq_len, qo_indptr, None
+
+
+@dataclass
+class EaglePPVerifyInputRaw(SpecInput):
+    """CPU-side draft tree produced by the PP last rank and relayed across PP
+    stages so non-last ranks can rebuild an EagleVerifyInput on the next iter.
+
+    Carries the raw (pre-tree-mask) fields rather than a built EagleVerifyInput
+    because the tree mask / positions must be rebuilt against each rank's own
+    attention backend buffers.
+    """
+
+    draft_tokens: List[List[int]]
+    bonus_tokens: List[int]
+    top_scores_index: List[List[int]]
+    parent_list: List[List[int]]
+    accept_lens: List[int]
+    accept_index: Optional[List] = None
+
+    def __post_init__(self):
+        super().__init__(SpecInputType.EAGLE_PP_VERIFY_INPUT_RAW)
+
+    def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
+        num_draft = (
+            len(self.draft_tokens[0])
+            if self.draft_tokens and isinstance(self.draft_tokens[0], list)
+            else 1
+        )
+        return num_draft, num_draft
+
+    def to_tensor_dict(self) -> dict:
+        return {"pp_spec_output": asdict(self)}
+
+    @classmethod
+    def from_pp_outputs(cls, pp_outputs):
+        return cls(**pp_outputs["pp_spec_output"])
+
+    @classmethod
+    def build_dummy_for_decode(
+        cls, batch: ScheduleBatch, num_draft: int
+    ) -> "EaglePPVerifyInputRaw":
+        """Build a dummy draft spec for the first decode step after prefill.
+
+        The last PP rank produces no draft tokens for prefill batches, so a
+        placeholder tree (each req's bonus token replicated num_draft times)
+        is constructed here.
+        """
+        bs = len(batch.reqs)
+        parent_width = max(num_draft - 1, 0)
+
+        bonus_tokens = batch.input_ids.tolist()
+        draft_tokens = [bonus_tokens[i : i + 1] * num_draft for i in range(bs)]
+        parent_row = list(range(-1, parent_width - 1))
+        parent_list = [parent_row[:] for _ in range(bs)]
+        score_row = list(range(parent_width))
+        top_scores_index = [score_row[:] for _ in range(bs)]
+
+        return cls(
+            draft_tokens=draft_tokens,
+            bonus_tokens=bonus_tokens,
+            top_scores_index=top_scores_index,
+            parent_list=parent_list,
+            accept_lens=[1] * bs,
+            accept_index=None,
+        )
+
+    def filter_batch(
+        self, new_indices: torch.Tensor, new_indices_cpu: Optional[List[int]] = None
+    ):
+        idx = new_indices.tolist()
+
+        def pick(lst):
+            return [lst[i] for i in idx]
+
+        try:
+            self.bonus_tokens = pick(self.bonus_tokens)
+            self.draft_tokens = pick(self.draft_tokens)
+            self.top_scores_index = pick(self.top_scores_index)
+            self.parent_list = pick(self.parent_list)
+            self.accept_lens = pick(self.accept_lens)
+            if self.accept_index is not None:
+                self.accept_index = [self.accept_index[i] for i in idx]
+        except TypeError as e:
+            raise RuntimeError(
+                "EaglePPVerifyInputRaw.filter_batch: a required field was None. "
+                "Under PP + EAGLE, every batch must carry the draft tree relayed "
+                "via pp_outputs, or be given a dummy tree for its first decode."
+            ) from e
+
+    def merge_batch(self, other: "EaglePPVerifyInputRaw"):
+        try:
+            if self.accept_index is not None and other.accept_index is not None:
+                self.accept_index = self.accept_index + other.accept_index
+            self.draft_tokens = self.draft_tokens + other.draft_tokens
+            self.bonus_tokens = self.bonus_tokens + other.bonus_tokens
+            self.top_scores_index = self.top_scores_index + other.top_scores_index
+            self.parent_list = self.parent_list + other.parent_list
+            self.accept_lens = self.accept_lens + other.accept_lens
+        except TypeError as e:
+            raise RuntimeError(
+                "EaglePPVerifyInputRaw.merge_batch: a required field was None. "
+                "Under PP + EAGLE, every batch must carry the draft tree relayed "
+                "via pp_outputs, or be given a dummy tree for its first decode."
+            ) from e

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -874,16 +874,9 @@ def eagle_sample(
     return predict, num_correct_drafts + 1, accept_index
 
 
-def eagle_prepare_for_decode(batch: ScheduleBatch):
-    batch.maybe_evict_swa()
-
+def eagle_reserve_for_decode(batch: ScheduleBatch):
+    """Reserve speculative KV slots without advancing decode bookkeeping."""
     bs = batch.batch_size()
-
-    # Accumulate penalty
-    # This is a relaxed version of penalties for speculative decoding.
-    if batch.sampling_info.penalizer_orchestrator.is_required:
-        batch.cumulate_penalty_output_tokens()
-
     page_size = batch.token_to_kv_pool_allocator.page_size
     double_alloc = get_alloc_reserve_per_decode()
 
@@ -907,7 +900,6 @@ def eagle_prepare_for_decode(batch: ScheduleBatch):
         cur_kv_lens[i] = cur
         nxt_kv_lens[i] = nxt
         num_needed_tokens += nxt - cur
-        r.decode_batch_idx += 1
 
     cur_kv_lens_cpu = torch.tensor(cur_kv_lens, dtype=torch.int32, device="cpu")
     nxt_kv_lens_cpu = torch.tensor(nxt_kv_lens, dtype=torch.int32, device="cpu")
@@ -918,7 +910,7 @@ def eagle_prepare_for_decode(batch: ScheduleBatch):
     # (PR #26972); fail here with a clear error, not on a later cryptic CUDA assert.
     from sglang.srt.runtime_context import get_server_args
 
-    if page_size > 1 and (get_server_args().speculative_eagle_topk or 1) > 1:
+    if bs > 0 and page_size > 1 and (get_server_args().speculative_eagle_topk or 1) > 1:
         max_alloc_len = int(nxt_kv_lens_cpu.max())
         row_width = batch.req_to_token_pool.req_to_token.shape[1]
         assert max_alloc_len <= row_width, (
@@ -949,3 +941,18 @@ def eagle_prepare_for_decode(batch: ScheduleBatch):
         num_needed_tokens=num_needed_tokens,
         batch=batch,
     )
+
+
+def eagle_prepare_for_decode(batch: ScheduleBatch, *, advance_bookkeeping: bool = True):
+    batch.maybe_evict_swa()
+
+    if advance_bookkeeping:
+        # Accumulate penalty
+        # This is a relaxed version of penalties for speculative decoding.
+        if batch.sampling_info.penalizer_orchestrator.is_required:
+            batch.cumulate_penalty_output_tokens()
+
+        for r in batch.reqs:
+            r.decode_batch_idx += 1
+
+    eagle_reserve_for_decode(batch)

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -15,6 +15,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
 )
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.eagle_utils import (
     TreeMaskMode,
@@ -414,10 +415,15 @@ def _finalize_accept_tree_path(
     hidden_states -- to the contiguous front of each per-req block, which the
     downstream chain-layout code (draft-extend select_index, committed-KV reads)
     assumes. Returns compacted predict; mutates logits_output.hidden_states
-    (moved only when present)."""
-    move_accept_tokens_to_target_kvcache(
-        batch, accept_index, accept_lens - 1, token_to_kv_pool_allocator
-    )
+    (moved only when present).
+
+    Under PP the KV move runs per-rank in the scheduler's batch_result_processor
+    (it needs each rank's own seq_lens / accept_index), so skip it here.
+    """
+    if get_parallel().pp_size == 1:
+        move_accept_tokens_to_target_kvcache(
+            batch, accept_index, accept_lens - 1, token_to_kv_pool_allocator
+        )
     predict = _compact_accept_to_front(
         predict, accept_index, bs, num_draft_tokens=num_draft_tokens
     )
@@ -469,6 +475,7 @@ def run_eagle_verify(
     metadata_ready_pre_pad: bool,
     finalize_tree_path: bool,
     grammar_barrier=None,
+    pp_proxy_tensors=None,
 ) -> GenerationBatchResult:
     """Shared verify step: target-verify forward, sampling, acceptance bookkeeping.
 
@@ -560,8 +567,16 @@ def run_eagle_verify(
         batch=None,
         forward_batch=verify_forward_batch,
         is_verify=True,
+        pp_proxy_tensors=pp_proxy_tensors,
     )
     logits_output = forward_batch_output.logits_output
+
+    # Non-last PP rank: only proxy hidden states, no logits — skip the
+    # sample/accept/grammar post-processing below.
+    pp_enabled = target_worker.server_args.pp_size > 1
+    pp_is_last_rank = target_worker.pp_group.is_last_rank
+    if pp_enabled and not pp_is_last_rank:
+        return forward_batch_output
 
     # Generate vocab mask for constrained decoding
     grammar_mask = None
@@ -650,6 +665,7 @@ def run_eagle_verify(
         speculative_num_draft_tokens=num_draft_tokens,
         next_draft_input=next_draft_input,
         accept_lens=accept_lens,
+        accept_index=accept_index,
         new_seq_lens=new_seq_lens,
         routed_experts_output=forward_batch_output.routed_experts_output,
         indexer_topk_output=forward_batch_output.indexer_topk_output,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -37,7 +37,11 @@ from sglang.srt.model_executor.cuda_graph_config import (
     Phase,
     check_cuda_graph_backend,
 )
-from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardBatch
+from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+)
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.runner import (
     DecodeCudaGraphRunner,
@@ -60,10 +64,13 @@ from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
 from sglang.srt.speculative.eagle_info import (
     EagleDraftExtendInput,
     EagleDraftInput,
+    EaglePPVerifyInputRaw,
     EagleVerifyInput,
 )
 from sglang.srt.speculative.eagle_utils import (
+    TreeMaskMode,
     _eagle_prefill_tail_tokens,
+    build_tree_kernel_efficient,
     default_tree_mask_mode,
     get_draft_recurrent_hidden_state_spec,
     organize_draft_results,
@@ -125,6 +132,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         ps: ParallelState,
         nccl_port: int,
         target_worker: TpModelWorker,
+        tree_mask_mode: TreeMaskMode,
     ):
         # copy args
         self.server_args = server_args
@@ -164,6 +172,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 ps=replace(ps, pp_rank=0),
                 nccl_port=nccl_port,
                 is_draft_worker=True,
+                pp_global_random_seed=target_worker.random_seed,
             )
 
         # Alias for better readability
@@ -174,7 +183,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self.draft_tp_context = (
             draft_tp_context if server_args.enable_dp_attention else empty_context
         )
-        self.tree_mask_mode = default_tree_mask_mode()
+        self.tree_mask_mode = tree_mask_mode
 
         self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
 
@@ -305,7 +314,14 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             self.hot_token_id = None
 
     def init_lm_head(self):
-        embed, head = self.target_worker.model_runner.model.get_embed_and_head()
+        pp_size = self.target_worker.pp_group.world_size
+
+        if pp_size > 1:
+            # Under PP, the draft embedding is loaded from the draft checkpoint
+            # in load_weights already; here we only take the target lm_head.
+            head = self.target_worker.model_runner.model.get_head()
+        else:
+            embed, head = self.target_worker.model_runner.model.get_embed_and_head()
         target_lm_head = getattr(self.target_worker.model_runner.model, "lm_head", None)
 
         def maybe_share_target_lm_head():
@@ -324,16 +340,18 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 hasattr(self.draft_runner.model, "load_lm_head_from_target")
                 and self.draft_runner.model.load_lm_head_from_target
             ):
-                self.draft_runner.model.set_embed_and_head(embed, head)
+                if pp_size > 1:
+                    self.draft_runner.model.set_head(head)
+                else:
+                    self.draft_runner.model.set_embed_and_head(embed, head)
                 maybe_share_target_lm_head()
             else:
-                self.draft_runner.model.set_embed(embed)
+                if pp_size == 1:
+                    self.draft_runner.model.set_embed(embed)
 
             # grab hot token ids
             if self.draft_runner.model.hot_token_id is not None:
-                self.hot_token_id = self.draft_runner.model.hot_token_id.to(
-                    embed.device
-                )
+                self.hot_token_id = self.draft_runner.model.hot_token_id.to(head.device)
 
         else:
             if self.hot_token_id is not None:
@@ -341,8 +359,12 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 self.hot_token_id = self.hot_token_id.to(head.device)
                 head.data = head.data[self.hot_token_id]
 
-            # Share the embedding and lm_head
-            self.draft_runner.model.set_embed_and_head(embed, head)
+            if pp_size > 1:
+                # Under PP the embed is already loaded by the draft; only set the head.
+                self.draft_runner.model.set_head(head)
+            else:
+                # Share the embedding and lm_head
+                self.draft_runner.model.set_embed_and_head(embed, head)
             maybe_share_target_lm_head()
 
     def init_attention_backend(self):
@@ -369,7 +391,6 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self.draft_runner.draft_attn_backend = self.draft_attn_backend
         if self.draft_extend_attn_backend is not None:
             self.draft_runner.attn_backend = self.draft_extend_attn_backend
-        self.tree_mask_mode = default_tree_mask_mode()
 
     def _capture_cuda_graphs(self):
         """Capture the draft worker's own cuda graphs (decode + draft-extend)."""
@@ -544,6 +565,31 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 parent_list, top_scores_index, draft_tokens, draft_probs = (
                     self.draft_forward(forward_batch)
                 )
+
+        if self.server_args.pp_size > 1:
+            # PP path: return the raw draft tree (flattened draft_tokens with
+            # bonus prepended, parent_list, top_scores_index) so the last PP
+            # rank can serialize it into EaglePPVerifyInputRaw for cross-rank relay.
+            if batch.forward_mode.is_idle():
+                num_draft = self.speculative_num_draft_tokens
+                parent_width = max(num_draft - 1, 0)
+                return (
+                    torch.empty((0, num_draft), dtype=torch.long, device="cpu"),
+                    torch.empty((0, parent_width), dtype=torch.long, device="cpu"),
+                    torch.empty((0, parent_width), dtype=torch.long, device="cpu"),
+                )
+
+            # CUDA Graph buffers are reused; clone before flattening so the
+            # relayed raw tokens survive the next replay.
+            if can_cuda_graph:
+                parent_list = parent_list.clone()
+                top_scores_index = top_scores_index.clone()
+                draft_tokens = draft_tokens.clone()
+
+            draft_tokens = torch.cat(
+                (draft_input.bonus_tokens.unsqueeze(1), draft_tokens), dim=1
+            ).flatten()
+            return draft_tokens, parent_list, top_scores_index
 
         return build_eagle_verify_input(
             batch,
@@ -1041,23 +1087,36 @@ class EAGLEWorkerV2(BaseSpecWorker):
             server_args.speculative_algorithm
         )
 
-        # Override the context length of the draft model to be the same as the target model.
-        server_args.override(
-            "spec_worker.match_target_context_length",
-            context_length=target_worker.model_runner.model_config.context_len,
-        )
+        self._pp_is_last_rank = target_worker.pp_group.is_last_rank
+        self._pp_enabled = server_args.pp_size > 1
 
-        self._draft_worker = EagleDraftWorker(
-            server_args,
-            gpu_id,
-            ps,
-            nccl_port,
-            target_worker,
-        )
+        # Defined on every rank so PP non-last ranks (which have no draft
+        # worker) still resolve the mask mode in _build_verify_input_from_pp_raw.
+        self.tree_mask_mode = default_tree_mask_mode()
+
+        # The draft model is only created on the last PP rank. PP + spec v2
+        # currently only supports hosting the draft worker on the last rank.
+        if not self._pp_enabled or self._pp_is_last_rank:
+            # Override the context length of the draft model to be the same as the target model.
+            server_args.override(
+                "spec_worker.match_target_context_length",
+                context_length=target_worker.model_runner.model_config.context_len,
+            )
+
+            self._draft_worker = EagleDraftWorker(
+                server_args,
+                gpu_id,
+                ps,
+                nccl_port,
+                target_worker,
+                tree_mask_mode=self.tree_mask_mode,
+            )
+        else:
+            self._draft_worker = None
 
         # Adaptive speculative
         self.adaptive_controller: Optional[AdaptiveController] = None
-        if server_args.speculative_adaptive:
+        if server_args.speculative_adaptive and self._draft_worker is not None:
             self.adaptive_controller = AdaptiveController(
                 self,
                 config_path=server_args.speculative_adaptive_config,
@@ -1081,6 +1140,10 @@ class EAGLEWorkerV2(BaseSpecWorker):
     def spec_v2_attn_backends(self) -> tuple:
         # Every attn backend a spec_v2 forward touches; consumed by
         # decide_needs_cpu_seq_lens to gate the seq_lens_cpu D2H.
+        # Non-last PP ranks have no draft model (_draft_worker is None) and
+        # only run the target forward, so only the target backend matters.
+        if self._draft_worker is None:
+            return (self._target_worker.model_runner.attn_backend,)
         return (
             self._target_worker.model_runner.attn_backend,
             self._draft_worker.draft_attn_backend,
@@ -1089,7 +1152,10 @@ class EAGLEWorkerV2(BaseSpecWorker):
         )
 
     def init_cuda_graphs(self):
-        super().init_cuda_graphs()
+        # The draft model only exists on the last PP rank; non-last PP ranks
+        # have no draft worker and skip the draft cuda graph / adaptive init.
+        if not self._pp_enabled or self._pp_is_last_rank:
+            self._draft_worker.init_cuda_graphs()
         # Build adaptive runtime states after target and draft backends exist.
         if self.adaptive_controller is not None:
             with (
@@ -1120,18 +1186,32 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 )
 
     def forward_batch_generation(
-        self, batch: ScheduleBatch, on_publish=None, grammar_barrier=None
+        self,
+        batch: ScheduleBatch,
+        on_publish=None,
+        grammar_barrier=None,
+        pp_proxy_tensors=None,
     ):
-        if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
-            # Target prefill
-            target_capture_mode = (
-                CaptureHiddenMode.NULL
-                if self.speculative_algorithm.is_standalone()
-                else CaptureHiddenMode.FULL
-            )
+        if batch.forward_mode.is_extend():
+            # Target prefill. Only the last PP rank needs to capture hidden
+            # states for the draft; non-last ranks relay upstream without capture.
+            if not self._pp_enabled or self._pp_is_last_rank:
+                target_capture_mode = (
+                    CaptureHiddenMode.NULL
+                    if self.speculative_algorithm.is_standalone()
+                    else CaptureHiddenMode.FULL
+                )
+            else:
+                target_capture_mode = CaptureHiddenMode.NULL
             batch_output = self.target_worker.forward_batch_generation(
-                batch, capture_hidden_mode=target_capture_mode
+                batch,
+                pp_proxy_tensors=pp_proxy_tensors,
+                capture_hidden_mode=target_capture_mode,
             )
+
+            # Non-last PP ranks only relay the target forward upstream.
+            if self._pp_enabled and not self._pp_is_last_rank:
+                return batch_output
 
             # Spec_v2 convention: batch.seq_lens = length BEFORE this iter's tokens.
             # Extend processed L prompt tokens; next verify iter expects same L.
@@ -1157,7 +1237,20 @@ class EAGLEWorkerV2(BaseSpecWorker):
                         batch_output.logits_output.mm_input_embeds,
                     )
                 )
-                return batch_output
+            return batch_output
+
+        # Decode
+        if batch.forward_mode.is_idle():
+            verify_input = EagleVerifyInput.create_idle_input(
+                self.topk,
+                self.speculative_num_steps,
+                self.speculative_num_draft_tokens,
+                device=self.device,
+            )
+        elif self._pp_enabled:
+            # Under PP the verify input is built from the raw draft tree relayed
+            # from the last PP rank of the previous iteration.
+            verify_input = self._build_verify_input_from_pp_raw(batch)
         else:
             self.activate_step_by_batch(batch.seq_lens.shape[0])
 
@@ -1192,29 +1285,152 @@ class EAGLEWorkerV2(BaseSpecWorker):
                     spec_stage_span("draft"),
                 ):
                     verify_input: EagleVerifyInput = self.draft_worker.draft(batch)
-            assert verify_input.is_verify_input()
-            batch.spec_info = verify_input
-            batch_output = self.verify(batch, grammar_barrier=grammar_barrier)
-            # Publish before draft_extend so the fence is at verify-end.
-            if on_publish is not None:
-                on_publish(batch_output.new_seq_lens)
-            if (
-                self.speculative_num_steps == 0
-                and envs.SGLANG_SPEC_SKIP_ZERO_STEP_DRAFT_EXTEND.get()
-            ):
-                self._stub_skipped_draft_extend(batch, batch_output)
-            else:
-                with (
-                    self.draft_worker.draft_tp_context(
-                        self.draft_worker.draft_runner.tp_group
-                    ),
-                    speculative_moe_backend_context(),
-                    speculative_moe_a2a_backend_context(),
-                    spec_stage_span("draft_extend"),
-                ):
-                    self.draft_worker._draft_extend_for_decode(batch, batch_output)
 
+        assert verify_input.is_verify_input()
+        batch.spec_info = verify_input
+        batch_output = self.verify(
+            batch, grammar_barrier=grammar_barrier, pp_proxy_tensors=pp_proxy_tensors
+        )
+
+        # Non-last PP ranks only relay the target verify forward upstream.
+        if self._pp_enabled and not self._pp_is_last_rank:
             return batch_output
+
+        # Publish before draft_extend so the fence is at verify-end.
+        if on_publish is not None:
+            on_publish(batch_output.new_seq_lens)
+
+        # All paths run draft-extend for decode; non-PP may skip it when
+        # drafting is disabled (num_steps == 0) and the env opt-in is set.
+        if (
+            not self._pp_enabled
+            and self.speculative_num_steps == 0
+            and envs.SGLANG_SPEC_SKIP_ZERO_STEP_DRAFT_EXTEND.get()
+        ):
+            self._stub_skipped_draft_extend(batch, batch_output)
+        else:
+            with (
+                self.draft_worker.draft_tp_context(
+                    self.draft_worker.draft_runner.tp_group
+                ),
+                speculative_moe_backend_context(),
+                speculative_moe_a2a_backend_context(),
+                spec_stage_span("draft_extend"),
+            ):
+                self.draft_worker._draft_extend_for_decode(batch, batch_output)
+
+                # PP last rank: produce next-iter draft raw for cross-rank relay.
+                if self._pp_enabled and self._pp_is_last_rank:
+                    batch.forward_mode = ForwardMode.DECODE
+                    batch.spec_info = batch_output.next_draft_input
+                    # Use post-accept seq_lens so draft/draft_extend write KV
+                    # at the correct slots.
+                    batch.seq_lens = batch_output.new_seq_lens
+                    pp_draft_tokens, pp_parent_list, pp_top_scores_index = (
+                        self.draft_worker.draft(batch)
+                    )
+
+        # PP last rank: serialize the draft tree for PP relay.
+        if self._pp_enabled and self._pp_is_last_rank:
+            batch_output.pp_verify_input_raw = EaglePPVerifyInputRaw(
+                draft_tokens=pp_draft_tokens.reshape(
+                    batch.batch_size(), self.speculative_num_draft_tokens
+                ).tolist(),
+                bonus_tokens=batch_output.next_draft_input.bonus_tokens.to(
+                    torch.int64
+                ).tolist(),
+                top_scores_index=pp_top_scores_index.tolist(),
+                parent_list=pp_parent_list.tolist(),
+                accept_lens=batch_output.accept_lens.tolist(),
+                accept_index=(
+                    batch_output.accept_index.tolist() if self.topk > 1 else None
+                ),
+            )
+
+        return batch_output
+
+    def _build_verify_input_from_pp_raw(self, batch: ScheduleBatch):
+        """Build EagleVerifyInput from EaglePPVerifyInputRaw (PP non-last rank).
+
+        The last PP rank serialized the draft tree into EaglePPVerifyInputRaw;
+        non-last ranks rebuild the tree mask / positions against their own
+        attention backend buffers here.
+        """
+        raw: EaglePPVerifyInputRaw = batch.spec_info
+        device = batch.seq_lens.device
+
+        topk = self.topk
+        spec_steps = self.speculative_num_steps
+        num_draft = self.speculative_num_draft_tokens
+
+        bonus_tokens = torch.tensor(raw.bonus_tokens, dtype=torch.long, device=device)
+        draft_tokens = torch.tensor(raw.draft_tokens, dtype=torch.long, device=device)
+        parent_list = torch.tensor(raw.parent_list, dtype=torch.long, device=device)
+        top_scores_index = torch.tensor(
+            raw.top_scores_index, dtype=torch.long, device=device
+        )
+
+        # draft_tokens is [bs, num_draft_tokens] with bonus as col 0.
+        # build_tree_kernel_efficient expects draft_tokens without bonus.
+        draft_tokens_no_bonus = draft_tokens[:, 1:]
+
+        # Directly write to cuda graph buffers for verify attn.
+        tree_mask_buf, position_buf = (
+            self.target_worker.model_runner.attn_backend.get_verify_buffers_to_fill_after_draft()
+        )
+
+        seq_lens_sum = batch.seq_lens_sum
+        if seq_lens_sum is None:
+            if batch.seq_lens_cpu is not None:
+                seq_lens_sum = int(batch.seq_lens_cpu.sum())
+            else:
+                seq_lens_sum = int(batch.seq_lens.sum())
+
+        bs = batch.seq_lens.shape[0]
+        assert parent_list.shape == (
+            bs,
+            num_draft - 1,
+        ), f"topology shape mismatch: {parent_list.shape} vs ({bs}, {num_draft - 1})"
+
+        (
+            tree_mask,
+            positions,
+            retrieve_index,
+            retrieve_next_token,
+            retrieve_next_sibling,
+            draft_tokens_arranged,
+        ) = build_tree_kernel_efficient(
+            bonus_tokens,
+            parent_list,
+            top_scores_index,
+            draft_tokens_no_bonus,
+            batch.seq_lens,
+            seq_lens_sum,
+            topk,
+            spec_steps,
+            num_draft,
+            self.tree_mask_mode,
+            tree_mask_buf,
+            position_buf,
+        )
+
+        draft_tokens_arranged = draft_tokens_arranged.to(torch.int64)
+        batch.input_ids = draft_tokens_arranged
+        return EagleVerifyInput(
+            draft_token=draft_tokens_arranged,
+            custom_mask=tree_mask,
+            positions=positions,
+            retrieve_index=retrieve_index,
+            retrieve_next_token=retrieve_next_token,
+            retrieve_next_sibling=retrieve_next_sibling,
+            retrieve_cum_len=None,
+            spec_steps=spec_steps,
+            topk=topk,
+            draft_token_num=num_draft,
+            capture_hidden_mode=CaptureHiddenMode.FULL,
+            seq_lens_sum=batch.seq_lens_sum,
+            seq_lens_cpu=batch.seq_lens_cpu,
+        )
 
     def _build_trivial_verify_input(self, batch: ScheduleBatch) -> EagleVerifyInput:
         """Build a 1-node EagleVerifyInput rooted at the previous bonus token.
@@ -1497,7 +1713,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             )
             dw._rebuild_topk1_chain_buffers()
 
-    def verify(self, batch: ScheduleBatch, grammar_barrier=None):
+    def verify(self, batch: ScheduleBatch, grammar_barrier=None, pp_proxy_tensors=None):
         return run_eagle_verify(
             batch,
             target_worker=self.target_worker,
@@ -1512,6 +1728,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             metadata_ready_pre_pad=False,
             finalize_tree_path=True,
             grammar_barrier=grammar_barrier,
+            pp_proxy_tensors=pp_proxy_tensors,
         )
 
     def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1192,7 +1192,21 @@ class EAGLEWorkerV2(BaseSpecWorker):
         grammar_barrier=None,
         pp_proxy_tensors=None,
     ):
-        if batch.forward_mode.is_extend():
+        # Under PP + DP attention, a rank with no local requests must still run
+        # in lockstep with the DP peers that are prefilling. On a global prefill
+        # step (some peer is extending, so the dp-attn all-gather sets
+        # is_extend_in_batch) the idle batch has to follow the *prefill* path so
+        # every DP rank emits the same MoE cross-DP collective sequence (target
+        # forward + a single draft_extend). Falling into the verify path below
+        # would add speculative_num_steps extra draft-decode collectives on the
+        # idle rank and desync the MoE all-gather -> hang. _draft_extend_for_prefill
+        # already short-circuits its input_ids build for idle batches.
+        run_as_prefill = batch.forward_mode.is_extend() or (
+            self._pp_enabled
+            and batch.forward_mode.is_idle()
+            and batch.is_extend_in_batch
+        )
+        if run_as_prefill:
             # Target prefill. Only the last PP rank needs to capture hidden
             # states for the draft; non-last ranks relay upstream without capture.
             if not self._pp_enabled or self._pp_is_last_rank:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -72,6 +72,7 @@ from sglang.srt.speculative.eagle_utils import (
     _eagle_prefill_tail_tokens,
     build_tree_kernel_efficient,
     default_tree_mask_mode,
+    eagle_prepare_for_decode,
     get_draft_recurrent_hidden_state_spec,
     organize_draft_results,
     per_step_draft_out_cache_loc,
@@ -1185,6 +1186,26 @@ class EAGLEWorkerV2(BaseSpecWorker):
                     ),
                 )
 
+    def _build_pp_verify_input_raw(
+        self,
+        batch: ScheduleBatch,
+        draft_tokens: torch.Tensor,
+        parent_list: torch.Tensor,
+        top_scores_index: torch.Tensor,
+        accept_lens: List[int],
+        accept_index: Optional[List] = None,
+    ) -> EaglePPVerifyInputRaw:
+        return EaglePPVerifyInputRaw(
+            draft_tokens=draft_tokens.reshape(
+                batch.batch_size(), self.speculative_num_draft_tokens
+            ).tolist(),
+            bonus_tokens=batch.spec_info.bonus_tokens.to(torch.int64).tolist(),
+            top_scores_index=top_scores_index.tolist(),
+            parent_list=parent_list.tolist(),
+            accept_lens=accept_lens,
+            accept_index=accept_index,
+        )
+
     def forward_batch_generation(
         self,
         batch: ScheduleBatch,
@@ -1251,6 +1272,49 @@ class EAGLEWorkerV2(BaseSpecWorker):
                         batch_output.logits_output.mm_input_embeds,
                     )
                 )
+
+                # Build the first real draft tree on the final PP rank so the
+                # next iteration can enter target verification directly.
+                if (
+                    self._pp_enabled
+                    and not self.server_args.enable_dp_attention
+                    and batch.contains_last_prefill_chunk
+                ):
+                    if not batch.forward_mode.is_idle():
+                        eagle_prepare_for_decode(batch, advance_bookkeeping=False)
+                    batch.forward_mode = (
+                        ForwardMode.IDLE
+                        if batch.forward_mode.is_idle()
+                        else ForwardMode.DECODE
+                    )
+
+                    # This inline draft bypasses the scheduler pass that normally
+                    # converts prefill metadata to decode metadata.
+                    if batch.global_num_tokens is not None:
+                        decode_batch_size = batch.batch_size()
+                        batch.global_num_tokens = [decode_batch_size]
+                        batch.global_num_tokens_for_logprob = [decode_batch_size]
+                    batch.is_extend_in_batch = False
+                    batch.tbo_split_seq_index = None
+                    if batch.global_forward_mode is not None:
+                        batch.global_forward_mode = batch.forward_mode
+                    batch.can_run_dp_cuda_graph = not check_cuda_graph_backend(
+                        Phase.DECODE, Backend.DISABLED
+                    )
+                    batch.can_run_dp_breakable_cuda_graph = False
+
+                    batch.spec_info = batch_output.next_draft_input
+                    batch.seq_lens = batch_output.new_seq_lens
+                    pp_draft_tokens, pp_parent_list, pp_top_scores_index = (
+                        self.draft_worker.draft(batch)
+                    )
+                    batch_output.pp_verify_input_raw = self._build_pp_verify_input_raw(
+                        batch,
+                        pp_draft_tokens,
+                        pp_parent_list,
+                        pp_top_scores_index,
+                        accept_lens=[1] * batch.batch_size(),
+                    )
             return batch_output
 
         # Decode
@@ -1346,15 +1410,11 @@ class EAGLEWorkerV2(BaseSpecWorker):
 
         # PP last rank: serialize the draft tree for PP relay.
         if self._pp_enabled and self._pp_is_last_rank:
-            batch_output.pp_verify_input_raw = EaglePPVerifyInputRaw(
-                draft_tokens=pp_draft_tokens.reshape(
-                    batch.batch_size(), self.speculative_num_draft_tokens
-                ).tolist(),
-                bonus_tokens=batch_output.next_draft_input.bonus_tokens.to(
-                    torch.int64
-                ).tolist(),
-                top_scores_index=pp_top_scores_index.tolist(),
-                parent_list=pp_parent_list.tolist(),
+            batch_output.pp_verify_input_raw = self._build_pp_verify_input_raw(
+                batch,
+                pp_draft_tokens,
+                pp_parent_list,
+                pp_top_scores_index,
                 accept_lens=batch_output.accept_lens.tolist(),
                 accept_index=(
                     batch_output.accept_index.tolist() if self.topk > 1 else None

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -306,6 +306,7 @@ class SpecInputType(IntEnum):
     EAGLE_DRAFT = auto()
     EAGLE_DRAFT_EXTEND = auto()
     EAGLE_VERIFY = auto()
+    EAGLE_PP_VERIFY_INPUT_RAW = auto()
     FROZEN_KV_MTP_DRAFT = auto()
     FROZEN_KV_MTP_VERIFY = auto()
     DFLASH_DRAFT = auto()


### PR DESCRIPTION
## Motivation

| | Dummy bootstrap | Real draft tree |
| --- | --- | --- |
| After prefill | Builds a dummy tree by repeating the bonus token | Runs `draft()` and builds a real tree |
| First decode step | Mainly serves as a bootstrap step | Can verify real draft tokens immediately |
| Extra work | No extra draft call | One extra draft call after prefill |
| Implementation | Simpler | More state handling between prefill and decode |



## Speed Tests and Profiling

- environment: 16 x H800
- model: GLM-5.2-FP8 (TP8 CP8 PP2)

**sglang command**
```bash
export SGLANG_ENABLE_UNIFIED_RADIX_TREE=1
export SGLANG_PP_LAYER_PARTITION=40,38
sglang serve \
    --model-path GLM-5.2-FP8 \
    --tp 8 \
    --pp-size 2 \
    --enable-prefill-cp \
    --cp-strategy interleave \
    --attn-cp-size 8 \
    --trust-remote-code \
    --disable-overlap-schedule \
    --nnodes 2 \
    --dist-init-addr ${ip}:5000 \
    --node-rank ${node} \
    --kv-cache-dtype fp8_e4m3 \
    --enable-cache-report \
    --reasoning-parser glm45 \
    --tool-call-parser glm47 \
    --mem-fraction-static 0.8 \
    --cuda-graph-max-bs-decode 64 \
    --port 8000 \
    --speculative-algorithm EAGLE \
    --speculative-num-steps 3 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 4
```

**benchmark command**
```bash
python -m sglang.benchmark.serving \
    --backend sglang-oai-chat \
    --port 8000 \
    --model GLM-5.2-FP8 \
    --dataset-name sharegpt \
    --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json \
    --request-rate inf \
    --max-concurrency 16 \
    --num-prompts 100 \
    --warmup-requests 10 \
    --flush-cache
```

| metric | prefill_dummy | prefill_draft | change |
|---|---:|---:|---:|
| output_throughput (tok/s) | 474.836 | 487.109 | +2.58% |
| mean_ttft (ms) | 349.051 | 345.166 | -1.11% |
| mean_tpot (ms) | 30.241 | 27.745 | -8.25% |
| mean_itl (ms) | 29.109 | 28.303 | -2.77% |
| accept_length | 2.954 | 2.997 | +1.45% |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #30509714031](https://github.com/antgroup/sglang/actions/runs/30509714031)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #30509713874](https://github.com/antgroup/sglang/actions/runs/30509713874)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->