### PR TITLE
[Diffusion] Add SM120 support for SubBlock sparse attention

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/subblock_sparse/README.md
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/subblock_sparse/README.md
@@ -1,7 +1,8 @@
 # SubBlock sparse attention — training-free block sparsity for the MiniMax-H3 DiT
 
 Routes the same 64-token SubBlock plan to SGLang's CuTe-DSL block-sparse
-FlashAttention kernel on SM90 or FlashInfer's `bsa_attn_blk64_fwd` on SM100.
+FlashAttention kernel on SM90 or FlashInfer's architecture-specific blk64
+kernels on SM100 and SM120.
 Nothing is trained and no weights change: a cheap estimator runs before
 attention and hands the selected kernel a `q2k_block_index`.
 
@@ -38,7 +39,7 @@ are listed below.
 
 | | |
 | --- | --- |
-| GPU | **compute capability 9.0 or 10.0** — H100 / H200 use SGLang's CuTe-DSL SM90 block-sparse FlashAttention kernel; B200 / GB200 use FlashInfer's architecture-specific `sm_100a` kernel. Other capabilities, including 10.3 (B300 / GB300) and 12.x (RTX PRO 6000, RTX 50xx), are rejected. |
+| GPU | **compute capability 9.0, 10.0, or 12.0** — H100 / H200 use SGLang's CuTe-DSL SM90 block-sparse FlashAttention kernel; B200 / GB200 use FlashInfer's architecture-specific `sm_100a` kernel; SM120 devices use FlashInfer's `bsa_attn_sm120_blk64_fwd` CuTe-DSL kernel. Other capabilities, including 10.3 (B300 / GB300), are rejected. |
 | dtype | bfloat16 |
 | head_dim | 128 |
 | attention | non-causal, one contiguous sequence per call |
@@ -48,10 +49,11 @@ refiner, sequences under `min_seq_len`, non-bf16 activations, head_dim != 128 �
 falls back to dense for that call, so no layer has to be excluded by hand.
 
 **On an unsupported GPU it is not a fallback, it is an error at startup.** The
-resolver accepts exactly compute capability 9.0 or 10.0 before loading either
-kernel, so a B300 or an SM12x GPU fails at launch rather than after ten dense
-denoise steps. The exact 10.0 check is required because FlashInfer's kernel is
-built for `sm_100a` and has no forward-compatible 10.3 cubin.
+resolver accepts exactly compute capability 9.0, 10.0, or 12.0 before loading
+the selected kernel, so a B300 or another unsupported capability fails at
+launch rather than after ten dense denoise steps. The exact 10.0 check is
+required because FlashInfer's kernel is built for `sm_100a` and has no
+forward-compatible 10.3 cubin.
 
 ## How the score works
 

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/subblock_sparse/__init__.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/subblock_sparse/__init__.py
@@ -6,11 +6,19 @@ Originally vendored from the standalone SubBlock repository; ``router.py`` and
 
 ``router.py`` scores every (query block, key block) pair from sub-block-pooled
 Q/K and turns the scores into a ``q2k_block_index`` consumed by SGLang's SM90
-CuTe-DSL block-sparse FlashAttention or FlashInfer's SM100
-``bsa_attn_blk64_fwd`` (bf16, head_dim 128). The estimator and the measurements
-behind its defaults are documented there.
+CuTe-DSL block-sparse FlashAttention or FlashInfer's architecture-specific
+SM100/SM120 blk64 kernels (bf16, head_dim 128). The estimator and the
+measurements behind its defaults are documented there.
 """
 
-from .router import SubBlockRouter, load_bsa_attn_blk64_fwd
+from .router import (
+    SubBlockRouter,
+    load_bsa_attn_blk64_fwd,
+    load_bsa_attn_sm120_blk64_fwd,
+)
 
-__all__ = ["SubBlockRouter", "load_bsa_attn_blk64_fwd"]
+__all__ = [
+    "SubBlockRouter",
+    "load_bsa_attn_blk64_fwd",
+    "load_bsa_attn_sm120_blk64_fwd",
+]

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/subblock_sparse/router.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/subblock_sparse/router.py
@@ -128,6 +128,22 @@ def load_bsa_attn_blk64_fwd():
     return mod.bsa_attn_blk64_fwd
 
 
+@functools.lru_cache(maxsize=1)
+def load_bsa_attn_sm120_blk64_fwd():
+    """FlashInfer's CuTe-DSL 64-block sparse attention entry point for SM120."""
+    try:
+        from flashinfer.cute_dsl.sparse.bsa_attn_sm120 import (
+            bsa_attn_sm120_blk64_fwd,
+        )
+    except Exception as exc:
+        raise ImportError(
+            "SM120 SubBlock sparse attention requires FlashInfer's "
+            "flashinfer.cute_dsl.sparse.bsa_attn_sm120 module"
+        ) from exc
+
+    return bsa_attn_sm120_blk64_fwd
+
+
 LOG2E = 1.4426950408889634
 BLOCK = 64  # the kernel's block granularity (kSparseBlockSize=64)
 BUDGET_GRANULARITY = 8  # blocks per query row the kernel bills in, padding to fit

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/subblock_sparse_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/subblock_sparse_attn.py
@@ -2,8 +2,9 @@
 """SubBlock block-sparse attention backend.
 
 Routes the same 64-token SubBlock plan to SGLang's CuTe-DSL block-sparse
-FlashAttention kernel on SM90 or FlashInfer's kernel on SM100. A log-sum-exp
-over query/key sub-block pairs selects the blocks (see ``backends/subblock_sparse/``).
+FlashAttention kernel on SM90 or FlashInfer's architecture-specific kernels on
+SM100 and SM120. A log-sum-exp over query/key sub-block pairs selects the blocks
+(see ``backends/subblock_sparse/``).
 Everything is training-free: the router runs before attention and produces
 the ``q2k_block_index`` the selected kernel consumes.
 
@@ -18,11 +19,11 @@ individual keys of the defaults below::
     --attention-backend-config '{"sparsity": 0.85}'
 
 Requirements inherited from the kernels: compute capability 9.0 (Hopper) or
-10.0 (B200 / GB200), bf16, head_dim 128. Hopper uses SGLang's CuTe-DSL SM90
-block-sparse FlashAttention kernel; B200 uses FlashInfer's ``sm_100a`` blk64
-kernel. Inside the DiT, any call the kernels cannot serve -- cross/refiner
-attention, short sequences, non-bf16 -- runs dense instead. On any other GPU
-the resolver refuses the backend at startup rather than falling back.
+10.0/12.0 (Blackwell), bf16, head_dim 128. Hopper uses SGLang's CuTe-DSL SM90
+block-sparse FlashAttention kernel; B200 and SM120 devices use FlashInfer's
+architecture-specific blk64 kernels. Inside the DiT, any call the kernels cannot
+serve -- cross/refiner attention, short sequences, non-bf16 -- runs dense instead.
+On any other GPU the resolver refuses the backend at startup rather than falling back.
 
 ``--attention-backend`` reaches every component, and the text encoder admits
 only fa / torch_sdpa / sage_attn_3, so pair it with
@@ -48,6 +49,7 @@ from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend i
 from sglang.multimodal_gen.runtime.layers.attention.backends.subblock_sparse import (
     SubBlockRouter,
     load_bsa_attn_blk64_fwd,
+    load_bsa_attn_sm120_blk64_fwd,
 )
 from sglang.multimodal_gen.runtime.managers.forward_context import get_forward_context
 from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
@@ -198,6 +200,29 @@ def _sm100_sparse_attention(
     return out[0] if isinstance(out, tuple) else out
 
 
+def _sm120_sparse_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q2k_block_index: torch.Tensor,
+    topk: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Run a SubBlock routing plan through FlashInfer's SM120 kernel."""
+    logger.info_once("SubBlock sparse attention kernel active: FlashInfer SM120 blk64")
+    out = load_bsa_attn_sm120_blk64_fwd()(
+        q,
+        k,
+        v,
+        q2k_block_index,
+        topk,
+        block_sizes=_cached_block_sizes(k.shape[1], k.device),
+        q2k_block_nums=None,  # the budget is uniform across rows
+        softmax_scale=softmax_scale,
+    )
+    return out[0] if isinstance(out, tuple) else out
+
+
 @functools.lru_cache(maxsize=None)
 def _get_subblock_sparse_attention_runner(device: torch.device):
     """Resolve the architecture-specific kernel once per CUDA device."""
@@ -206,8 +231,10 @@ def _get_subblock_sparse_attention_runner(device: torch.device):
         return _sm90_sparse_attention
     if capability == (10, 0):
         return _sm100_sparse_attention
+    if capability == (12, 0):
+        return _sm120_sparse_attention
     raise RuntimeError(
-        "SubBlock sparse attention supports compute capability 9.0 or 10.0; "
+        "SubBlock sparse attention supports compute capability 9.0, 10.0, or 12.0; "
         f"this tensor is on a {capability[0]}.{capability[1]} device."
     )
 

--- a/python/sglang/multimodal_gen/runtime/platforms/cuda.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/cuda.py
@@ -297,10 +297,10 @@ class _VMOBAAttentionBackendResolver(_CudaAttentionBackendResolver):
 class _SubBlockSparseAttentionBackendResolver(_CudaAttentionBackendResolver):
     backend = AttentionBackendEnum.SUBBLOCK_SPARSE_ATTN
 
-    # Hopper uses SGLang's SM90 CuTe-DSL block-sparse kernel. Blackwell uses the
-    # FlashInfer blk64 kernel built specifically for sm_100a; 10.3 and 12.x do
-    # not have a compatible cubin and must still fail closed.
-    supported_capabilities = {(9, 0), (10, 0)}
+    # Hopper uses SGLang's SM90 CuTe-DSL block-sparse kernel. SM100 uses
+    # FlashInfer's architecture-specific sm_100a kernel; SM120 uses FlashInfer's
+    # CuTe-DSL SM120 blk64 kernel. Other capabilities still fail closed.
+    supported_capabilities = {(9, 0), (10, 0), (12, 0)}
 
     @classmethod
     def resolve(cls, platform) -> str:
@@ -311,8 +311,8 @@ class _SubBlockSparseAttentionBackendResolver(_CudaAttentionBackendResolver):
         if capability_tuple not in cls.supported_capabilities:
             found = capability.as_version_str() if capability else "unknown"
             raise ValueError(
-                "SubBlock sparse attention needs compute capability 9.0 "
-                f"(Hopper) or 10.0 (B200 / GB200); this device reports {found}."
+                "SubBlock sparse attention needs compute capability 9.0, 10.0, "
+                f"or 12.0; this device reports {found}."
             )
         try:
             from sglang.multimodal_gen.runtime.layers.attention.backends.subblock_sparse_attn import (  # noqa: F401
@@ -328,20 +328,31 @@ class _SubBlockSparseAttentionBackendResolver(_CudaAttentionBackendResolver):
                 from sglang.kernels.ops.attention.flash_attn.cute.interface import (  # noqa: F401
                     flash_attn_func,
                 )
-            else:
+            elif capability_tuple == (10, 0):
                 from sglang.multimodal_gen.runtime.layers.attention.backends.subblock_sparse import (  # noqa: F401
                     load_bsa_attn_blk64_fwd,
                 )
 
                 load_bsa_attn_blk64_fwd()
+            else:
+                from sglang.multimodal_gen.runtime.layers.attention.backends.subblock_sparse import (
+                    load_bsa_attn_sm120_blk64_fwd,
+                )
+
+                load_bsa_attn_sm120_blk64_fwd()
             return "sglang.multimodal_gen.runtime.layers.attention.backends.subblock_sparse_attn.SubBlockSparseAttentionBackend"
         except Exception as e:
             logger.error("Failed to import SubBlock sparse attention: %s", str(e))
             dependency = (
                 "SGLang's SM90 CuTe-DSL FlashAttention dependencies"
                 if capability_tuple == (9, 0)
-                else "FlashInfer with the blk64 block-sparse kernel "
-                "(flashinfer.cute_dsl.sparse.bsa_attn_blk64_fwd)"
+                else (
+                    "FlashInfer with the SM100 blk64 block-sparse kernel "
+                    "(flashinfer.cute_dsl.sparse.bsa_attn_blk64_fwd)"
+                    if capability_tuple == (10, 0)
+                    else "FlashInfer with the SM120 blk64 block-sparse kernel "
+                    "(flashinfer.cute_dsl.sparse.bsa_attn_sm120)"
+                )
             )
             raise ImportError(f"SubBlock sparse attention needs {dependency}.") from e
 

--- a/test/registered/cpu/test_subblock_sparse_attention.py
+++ b/test/registered/cpu/test_subblock_sparse_attention.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import torch
 
@@ -9,6 +9,10 @@ from sglang.multimodal_gen.runtime.layers.attention.backends.subblock_sparse_att
     _get_subblock_sparse_attention_runner,
     _sm90_sparse_attention,
     _sm100_sparse_attention,
+    _sm120_sparse_attention,
+)
+from sglang.multimodal_gen.runtime.platforms.cuda import (
+    _SubBlockSparseAttentionBackendResolver,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -40,12 +44,69 @@ class TestSubBlockSparseAttentionDispatch(CustomTestCase):
 
         self.assertIs(runner, _sm100_sparse_attention)
 
+    def test_dispatches_sm120(self):
+        device = torch.device("cuda:0")
+        with patch("torch.cuda.get_device_capability", return_value=(12, 0)):
+            runner = _get_subblock_sparse_attention_runner(device)
+
+        self.assertIs(runner, _sm120_sparse_attention)
+
+    def test_platform_resolver_loads_sm120_dependency(self):
+        capability = Mock(major=12, minor=0)
+        capability.as_version_str.return_value = "12.0"
+        platform = Mock()
+        platform.get_device_capability.return_value = capability
+
+        with patch(
+            "sglang.multimodal_gen.runtime.layers.attention.backends."
+            "subblock_sparse.load_bsa_attn_sm120_blk64_fwd"
+        ) as load_sm120:
+            resolved = _SubBlockSparseAttentionBackendResolver.resolve(platform)
+
+        self.assertEqual(
+            resolved,
+            "sglang.multimodal_gen.runtime.layers.attention.backends."
+            "subblock_sparse_attn.SubBlockSparseAttentionBackend",
+        )
+        load_sm120.assert_called_once_with()
+
+    def test_sm120_adapter_forwards_subblock_plan(self):
+        q = torch.empty((1, 64, 2, 128), dtype=torch.bfloat16)
+        k = torch.empty((1, 65, 2, 128), dtype=torch.bfloat16)
+        v = torch.empty_like(k)
+        q2k_block_index = torch.zeros((1, 2, 1, 2), dtype=torch.int32)
+        expected = torch.empty_like(q)
+        kernel = Mock(return_value=(expected, None))
+
+        with patch(
+            "sglang.multimodal_gen.runtime.layers.attention.backends."
+            "subblock_sparse_attn.load_bsa_attn_sm120_blk64_fwd",
+            return_value=kernel,
+        ):
+            result = _sm120_sparse_attention(
+                q, k, v, q2k_block_index, topk=2, softmax_scale=0.125
+            )
+
+        self.assertIs(result, expected)
+        kernel.assert_called_once()
+        args, kwargs = kernel.call_args
+        self.assertIs(args[0], q)
+        self.assertIs(args[1], k)
+        self.assertIs(args[2], v)
+        self.assertIs(args[3], q2k_block_index)
+        self.assertEqual(args[4], 2)
+        torch.testing.assert_close(
+            kwargs["block_sizes"], torch.tensor([64, 1], dtype=torch.int32)
+        )
+        self.assertIsNone(kwargs["q2k_block_nums"])
+        self.assertEqual(kwargs["softmax_scale"], 0.125)
+
     def test_rejects_unsupported_compute_capability(self):
         device = torch.device("cuda:0")
         with patch("torch.cuda.get_device_capability", return_value=(10, 3)):
             with self.assertRaisesRegex(
                 RuntimeError,
-                "supports compute capability 9.0 or 10.0;.*10.3 device",
+                "supports compute capability 9.0, 10.0, or 12.0;.*10.3 device",
             ):
                 _get_subblock_sparse_attention_runner(device)
 


### PR DESCRIPTION
## Motivation

SubBlock sparse attention currently supports Hopper (SM90) and datacenter
Blackwell (SM100), but rejects client/workstation Blackwell devices with
compute capability 12.0 even when FlashInfer's architecture-specific SM120
blk64 kernel is installed.

This change adds an exact SM120 path while preserving the existing fail-closed
behavior for unsupported capabilities such as 10.3.

## Modifications

- Add a lazy loader for
  `flashinfer.cute_dsl.sparse.bsa_attn_sm120.bsa_attn_sm120_blk64_fwd`.
- Add the SGLang SM120 adapter and exact `(12, 0)` device dispatch.
- Allow compute capability 12.0 in the CUDA SubBlock backend resolver and
  validate the SM120 dependency during backend resolution.
- Keep the existing SM90 and SM100 paths unchanged.
- Add CPU unit coverage for SM120 dispatch, dependency resolution, adapter
  argument forwarding, ragged block sizes, and unsupported-device rejection.
- Update the SubBlock backend documentation with the SM120 requirements.

No image, build-pipeline, Docker, or dependency-lock files are included.

## Accuracy Tests

Validated on NVIDIA RTX PRO 5000 72GB Blackwell (compute capability 12.0),
BF16, head dimension 128:

- Direct FlashInfer SM120 output and the SGLang adapter output were bit-equal.
- A 257-token ragged case used block sizes `[64, 64, 64, 64, 1]` and matched
  an FP32 dense oracle:
  - max absolute error: `0.0018635988235473633`
  - mean absolute error: `0.00016255080117844045`
- Extended full/sparse/router/stress coverage passed independently on six
  RTX PRO 5000 devices, including sequence lengths 65, 257, 1025, 4097, and
  a 16,385-token deterministic stress case.

CPU tests:

```text
python test/registered/cpu/test_subblock_sparse_attention.py
Ran 6 tests in 0.004s
OK
```

Additional checks: Python compilation, Ruff lint, Ruff format check, exact
six-file allowlist, content-safety gates, and `git diff --check`.

## Speed Tests and Profiling

Synthetic steady-state kernel-level benchmark at sequence length 16,385,
BF16, head dimension 128, and 2 heads. The primary metric includes both
`SubBlockRouter.route` and SM120 sparse attention.

| Requested sparsity | Actual density | Dense SDPA | Router + SM120 sparse | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 0.50 | 52.92% | 1.5706 ms | 0.7474 ms | 2.101x |
| 0.75 | 28.02% | 1.5294 ms | 0.4122 ms | 3.710x |

For sparsity 0.50, the values are medians across six devices running
concurrently; the cross-device speedup range was `2.084x-2.118x`. For sparsity
0.75, the values are single-device medians from 30 interleaved samples with
five calls per sample. These are kernel-level benchmarks, not distributed
model throughput claims.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
