### PR TITLE
fix(scheduler): isolate single-request failures instead of crashing the whole server

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -888,6 +888,20 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
 
+            if poll not in (
+                KVPoll.Bootstrapping,
+                KVPoll.WaitingForInput,
+                KVPoll.Failed,
+            ):
+                # A protocol violation from the transfer backend fails only
+                # this request instead of crashing the whole scheduler.
+                logger.error(
+                    f"Unexpected poll state {poll} for req {decode_req.req.rid} "
+                    "during the decode handshake; treating it as a handshake "
+                    "failure for this request."
+                )
+                poll = KVPoll.Failed
+
             if poll == KVPoll.Bootstrapping:
                 pass
             elif poll == KVPoll.WaitingForInput:
@@ -913,8 +927,6 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 )
                 if self.scheduler.metrics_reporter.enable_metrics:
                     self.scheduler.metrics_collector.increment_bootstrap_failed_reqs()
-            else:
-                raise ValueError(f"Unexpected poll case: {poll}")
 
     def _ensure_prefill_info(
         self, addr_to_reqs: Dict[str, List[DecodeRequest]]
@@ -2267,6 +2279,21 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 continue
 
             hicache_restore_status = decode_req.hicache_restore_status
+            if poll not in (
+                KVPoll.Bootstrapping,
+                KVPoll.WaitingForInput,
+                KVPoll.Transferring,
+                KVPoll.Success,
+                KVPoll.Failed,
+            ):
+                # A protocol violation from the transfer backend fails only
+                # this request instead of crashing the whole scheduler.
+                logger.error(
+                    f"Unexpected poll state {poll} for req {decode_req.req.rid} "
+                    "in the decode transfer queue; treating it as a transfer "
+                    "failure for this request."
+                )
+                poll = KVPoll.Failed
             if (
                 poll == KVPoll.Failed
                 or hicache_restore_status == HiCacheRestoreResult.FAILED
@@ -2349,8 +2376,6 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 KVPoll.Transferring,
             ]:
                 pass
-            else:
-                raise ValueError(f"Unexpected poll case: {poll}")
 
         for i in indices_to_remove:
             if i in deferred_indices:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -883,7 +883,9 @@ class SchedulerDisaggregationPrefillMixin:
                 if self.handle_pending_bootstrap(req, poll):
                     self.send_kv_chunk(req, last_chunk=True)
                     undone_reqs.append(req)
-                elif poll != KVPoll.Failed:
+                elif not isinstance(req.finished_reason, FINISH_ABORT):
+                    # Keep waiting unless handle_pending_bootstrap concluded
+                    # the request as a bootstrap failure.
                     undone_reqs.append(req)
                 continue
 
@@ -902,9 +904,14 @@ class SchedulerDisaggregationPrefillMixin:
                 self.handle_inflight_transfer_failure(req)
                 done_reqs.append(req)
             else:
-                raise RuntimeError(
-                    f"Unexpected poll state {poll} for req {req.rid} in inflight queue"
+                # A protocol violation from the transfer backend fails only
+                # this request instead of crashing the whole scheduler.
+                logger.error(
+                    f"Unexpected poll state {poll} for req {req.rid} in inflight "
+                    "queue; treating it as a transfer failure for this request."
                 )
+                self.handle_inflight_transfer_failure(req)
+                done_reqs.append(req)
 
         for req in done_reqs:
             req.time_stats.set_completion_time()
@@ -1030,9 +1037,15 @@ class SchedulerDisaggregationPrefillMixin:
             assert self.disagg_prefill_bootstrap_queue.finalize_bootstrap(req)
             return True
         else:
-            raise RuntimeError(
-                f"Unexpected poll state {poll} for req {req.rid} in handle_pending_bootstrap"
+            # A protocol violation from the transfer backend fails only this
+            # request instead of crashing the whole scheduler.
+            logger.error(
+                f"Unexpected poll state {poll} for req {req.rid} in "
+                "handle_pending_bootstrap; treating it as a bootstrap failure "
+                "for this request."
             )
+            self.handle_bootstrap_failure(req)
+            return False
 
     def check_bootstrap(self: Scheduler, req: Req) -> bool:
         """Check bootstrap status for an optimistic prefilled request.

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -392,7 +392,8 @@ class Envs:
     SGLANG_TEST_STUCK_SCHEDULER_INIT = EnvFloat(0)
     SGLANG_TEST_STUCK_TOKENIZER = EnvFloat(0)
     SGLANG_TEST_CRASH_AFTER_STREAM_OUTPUTS = EnvInt(0)
-    # Scheduler: raise once from the first run_batch to exercise event-loop recovery
+    # Scheduler: raise from run_batch for rid-marked requests (see
+    # TEST_RECOVERY_CRASH_RID_MARKER) to exercise event-loop recovery
     SGLANG_TEST_SCHEDULER_RECOVERY_CRASH = EnvBool(False)
     SGLANG_TEST_REQUEST_TIME_STATS = EnvBool(False)
     SGLANG_TEST_DISAGG_FAILURE_PROB = EnvFloat(0.0)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -392,6 +392,8 @@ class Envs:
     SGLANG_TEST_STUCK_SCHEDULER_INIT = EnvFloat(0)
     SGLANG_TEST_STUCK_TOKENIZER = EnvFloat(0)
     SGLANG_TEST_CRASH_AFTER_STREAM_OUTPUTS = EnvInt(0)
+    # Scheduler: raise once from the first run_batch to exercise event-loop recovery
+    SGLANG_TEST_SCHEDULER_RECOVERY_CRASH = EnvBool(False)
     SGLANG_TEST_REQUEST_TIME_STATS = EnvBool(False)
     SGLANG_TEST_DISAGG_FAILURE_PROB = EnvFloat(0.0)
     SGLANG_TEST_RETRACT = EnvBool(False)
@@ -567,6 +569,9 @@ class Envs:
     SGLANG_SCHEDULER_SKIP_ALL_GATHER = EnvBool(False)
     SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE = EnvBool(False)
     SGLANG_KILLPG_ON_SCHEDULER_EXCEPTION = EnvBool(False)
+    # With --enable-scheduler-recovery: per-step budget (seconds) for the
+    # cross-rank recovery consensus barrier and the in-flight work drain.
+    SGLANG_SCHEDULER_RECOVERY_TIMEOUT = EnvFloat(10.0)
     SGLANG_REQ_WAITING_TIMEOUT = EnvFloat(-1)  # in seconds
     SGLANG_REQ_RUNNING_TIMEOUT = EnvFloat(-1)  # in seconds
     # For non-streaming requests, the scheduler still flushes intermediate

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -214,6 +214,11 @@ from sglang.srt.managers.scheduler_components.batch_result_processor import (
     SchedulerBatchResultProcessor,
 )
 from sglang.srt.managers.scheduler_components.dp_attn import SchedulerDPAttnAdapter
+from sglang.srt.managers.scheduler_components.error_isolation import (
+    filter_failed_materialization,
+    guard_request_admission,
+    run_event_loop_with_recovery,
+)
 from sglang.srt.managers.scheduler_components.flush_wrapper import SchedulerFlushWrapper
 from sglang.srt.managers.scheduler_components.idle_sleeper import (
     IdleSleeper,
@@ -1171,6 +1176,8 @@ class Scheduler(
         self.session_controller = SessionController(self.tree_cache)
         self.forward_sleep_time = None
         self._engine_paused = False
+        # Test hook: crash the first forward once to exercise event-loop recovery.
+        self._pending_test_loop_crash = envs.SGLANG_TEST_SCHEDULER_RECOVERY_CRASH.get()
 
     def init_chunked_prefill(self):
         self.chunked_prefill_size = get_schedule().chunked_prefill_size
@@ -1570,8 +1577,8 @@ class Scheduler(
     def init_request_dispatcher(self):
         self._request_dispatcher = TypeBasedDispatcher(
             [
-                (TokenizedGenerateReqInput, self.handle_generate_request),
-                (TokenizedEmbeddingReqInput, self.handle_embedding_request),
+                (TokenizedGenerateReqInput, self.handle_generate_request_guarded),
+                (TokenizedEmbeddingReqInput, self.handle_embedding_request_guarded),
                 (BatchTokenizedGenerateReqInput, self.handle_batch_generate_request),
                 (BatchTokenizedEmbeddingReqInput, self.handle_batch_embedding_request),
                 (FlushCacheReqInput, self.flush_wrapper.handle),
@@ -1722,7 +1729,7 @@ class Scheduler(
         if use_mlx():
             # MLX overlap uses mx.async_eval for CPU/GPU overlap,
             # not PyTorch MPS streams.
-            dispatch_event_loop(self)
+            run_event_loop_with_recovery(self, lambda: dispatch_event_loop(self))
             return
 
         self.schedule_stream = self.device_module.Stream(priority=0)
@@ -1744,7 +1751,7 @@ class Scheduler(
         # on the previous forward's read of the unified memory pool.
         self._war_barrier_enabled = is_cuda() or envs.SGLANG_ENABLE_WAR_BARRIER.get()
         with self.device_module.StreamContext(self.schedule_stream):
-            dispatch_event_loop(self)
+            run_event_loop_with_recovery(self, lambda: dispatch_event_loop(self))
 
     def _apply_war_barrier(self):
         # WAR: keep later schedule_stream writes behind this forward's shared reads.
@@ -1922,8 +1929,10 @@ class Scheduler(
         now = time.monotonic()
         self.session_controller.maybe_reap(now)
         if get_mm().mm_feature_transport == "cuda_vmm":
-            for recv_req in recv_reqs:
-                self._materialize_cuda_vmm_inputs(recv_req)
+            # A malformed multimodal payload aborts only its own request.
+            recv_reqs = filter_failed_materialization(
+                self, recv_reqs, self._materialize_cuda_vmm_inputs
+            )
 
         for recv_req in recv_reqs:
             # Skip health check when server is busy — ongoing requests already carry health info.
@@ -2438,6 +2447,20 @@ class Scheduler(
             mm_inputs.release_features()
             req.multimodal_inputs = None
 
+    def handle_generate_request_guarded(
+        self,
+        recv_req: TokenizedGenerateReqInput,
+    ):
+        # An unexpected admission error aborts only this request (per-request
+        # error isolation) instead of crashing the whole scheduler.
+        guard_request_admission(self, self.handle_generate_request, recv_req)
+
+    def handle_embedding_request_guarded(
+        self,
+        recv_req: TokenizedEmbeddingReqInput,
+    ):
+        guard_request_admission(self, self.handle_embedding_request, recv_req)
+
     def handle_generate_request(
         self,
         recv_req: TokenizedGenerateReqInput,
@@ -2766,9 +2789,9 @@ class Scheduler(
         """Handle optimized batch generate request."""
         logger.debug(f"Processing batch generate request with {len(recv_req)} requests")
 
-        # Process each request in the batch
+        # Process each request in the batch with per-request error isolation.
         for tokenized_req in recv_req:
-            self.handle_generate_request(tokenized_req)
+            self.handle_generate_request_guarded(tokenized_req)
 
     def _prefetch_kvcache(self, req: Req):
         if self.enable_hicache_storage:
@@ -3019,9 +3042,9 @@ class Scheduler(
             f"Processing batch embedding request with {len(recv_req)} requests"
         )
 
-        # Process each request in the batch
+        # Process each request in the batch with per-request error isolation.
         for tokenized_req in recv_req:
-            self.handle_embedding_request(tokenized_req)
+            self.handle_embedding_request_guarded(tokenized_req)
 
     def stash_chunked_request(self, req: Req):
         maybe_cache_unfinished_req(req, self.tree_cache, chunked=True)
@@ -3782,6 +3805,12 @@ class Scheduler(
         batch.launch_ts = time.monotonic()
         batch.after_idle_gap = self._sched_idled
         self._sched_idled = False
+
+        if self._pending_test_loop_crash:
+            self._pending_test_loop_crash = False
+            raise RuntimeError(
+                "Injected scheduler crash (SGLANG_TEST_SCHEDULER_RECOVERY_CRASH)"
+            )
 
         if self.scripted_scheduler_hook is not None:
             self.scripted_scheduler_hook.on_run_batch(batch)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -364,6 +364,10 @@ TEST_RETRACT = envs.SGLANG_TEST_RETRACT.get()
 TEST_RETRACT_INTERVAL = envs.SGLANG_TEST_RETRACT_INTERVAL.get()
 TEST_RETRACT_NO_PREFILL_BS = envs.SGLANG_TEST_RETRACT_NO_PREFILL_BS.get()
 
+# Test hook: crash the forward of rid-marked requests (see
+# TEST_RECOVERY_CRASH_RID_MARKER) to exercise event-loop recovery e2e.
+TEST_RECOVERY_CRASH = envs.SGLANG_TEST_SCHEDULER_RECOVERY_CRASH.get()
+
 
 STEP_MAX_US = 2_000_000
 
@@ -1177,9 +1181,6 @@ class Scheduler(
         self.session_controller = SessionController(self.tree_cache)
         self.forward_sleep_time = None
         self._engine_paused = False
-        # Test hook: crash the forward of rid-marked requests to exercise
-        # event-loop recovery e2e.
-        self._test_loop_crash_enabled = envs.SGLANG_TEST_SCHEDULER_RECOVERY_CRASH.get()
 
     def init_chunked_prefill(self):
         self.chunked_prefill_size = get_schedule().chunked_prefill_size
@@ -3808,7 +3809,7 @@ class Scheduler(
         batch.after_idle_gap = self._sched_idled
         self._sched_idled = False
 
-        if self._test_loop_crash_enabled and any(
+        if TEST_RECOVERY_CRASH and any(
             TEST_RECOVERY_CRASH_RID_MARKER in req.rid for req in batch.reqs
         ):
             raise RuntimeError(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -215,6 +215,7 @@ from sglang.srt.managers.scheduler_components.batch_result_processor import (
 )
 from sglang.srt.managers.scheduler_components.dp_attn import SchedulerDPAttnAdapter
 from sglang.srt.managers.scheduler_components.error_isolation import (
+    TEST_RECOVERY_CRASH_RID_MARKER,
     filter_failed_materialization,
     guard_request_admission,
     run_event_loop_with_recovery,
@@ -1176,8 +1177,9 @@ class Scheduler(
         self.session_controller = SessionController(self.tree_cache)
         self.forward_sleep_time = None
         self._engine_paused = False
-        # Test hook: crash the first forward once to exercise event-loop recovery.
-        self._pending_test_loop_crash = envs.SGLANG_TEST_SCHEDULER_RECOVERY_CRASH.get()
+        # Test hook: crash the forward of rid-marked requests to exercise
+        # event-loop recovery e2e.
+        self._test_loop_crash_enabled = envs.SGLANG_TEST_SCHEDULER_RECOVERY_CRASH.get()
 
     def init_chunked_prefill(self):
         self.chunked_prefill_size = get_schedule().chunked_prefill_size
@@ -3806,8 +3808,9 @@ class Scheduler(
         batch.after_idle_gap = self._sched_idled
         self._sched_idled = False
 
-        if self._pending_test_loop_crash:
-            self._pending_test_loop_crash = False
+        if self._test_loop_crash_enabled and any(
+            TEST_RECOVERY_CRASH_RID_MARKER in req.rid for req in batch.reqs
+        ):
             raise RuntimeError(
                 "Injected scheduler crash (SGLANG_TEST_SCHEDULER_RECOVERY_CRASH)"
             )

--- a/python/sglang/srt/managers/scheduler_components/error_isolation.py
+++ b/python/sglang/srt/managers/scheduler_components/error_isolation.py
@@ -45,6 +45,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# With SGLANG_TEST_SCHEDULER_RECOVERY_CRASH enabled, Scheduler.run_batch
+# raises for any batch containing a request whose rid carries this marker;
+# the e2e recovery test poisons exactly the requests it chooses with it.
+TEST_RECOVERY_CRASH_RID_MARKER = "sglang-test-recovery-crash"
+
 # Message substrings that indicate the CUDA/HIP context or the communication
 # layer is likely poisoned. Recovering in-place after one of these would risk
 # hangs or silent corruption, so they keep the crash behavior.
@@ -121,9 +126,7 @@ def _abort_output_for_req(req: Req, message: str) -> AbortReq:
 # =============================================================================
 
 
-def guard_request_admission(
-    scheduler: Scheduler, handler: Callable, recv_req
-) -> None:
+def guard_request_admission(scheduler: Scheduler, handler: Callable, recv_req) -> None:
     """Run one tokenized request through ``handler``; on an unexpected
     exception, abort only this request instead of crashing the scheduler."""
     try:
@@ -244,8 +247,7 @@ def try_recover_from_loop_crash(scheduler: Scheduler, exc: Exception) -> bool:
     """Attempt in-place recovery. Returns True when the scheduler is safe to
     keep serving; False re-raises the original exception (process crash)."""
     logger.error(
-        "Scheduler event loop hit an exception; attempting in-place "
-        "recovery: %s",
+        "Scheduler event loop hit an exception; attempting in-place recovery: %s",
         get_exception_traceback(),
     )
     if not is_recoverable_exception(exc):

--- a/python/sglang/srt/managers/scheduler_components/error_isolation.py
+++ b/python/sglang/srt/managers/scheduler_components/error_isolation.py
@@ -1,0 +1,463 @@
+"""Per-request error isolation and in-place crash recovery for the scheduler.
+
+A single bad request must not take down the whole server. This module provides
+two layers of protection:
+
+1. Request-admission guard (always on): an unexpected exception raised while
+   admitting one tokenized request (``handle_generate_request`` /
+   ``handle_embedding_request``) aborts only that request with an internal
+   error response. Admission runs the same deterministic, content-driven code
+   on every TP rank (requests are broadcast from attn-TP rank 0), so a local
+   abort decision is rank-consistent, matching the existing whitelisted
+   ``set_finish_with_abort`` validation paths.
+
+2. Event-loop recovery (opt-in via ``--enable-scheduler-recovery``): an
+   unexpected exception escaping the scheduler event loop (e.g. from the model
+   forward path) aborts every in-flight request with an internal error
+   response, resets the KV cache and scheduling state, and resumes serving.
+   This trades the affected requests for the server's uptime: clients receive
+   HTTP 500 and can retry immediately instead of losing the server for a full
+   restart and weight reload. Errors that indicate a corrupted process (CUDA
+   context poison, communicator failures, host OOM) are never recovered from;
+   they keep the existing crash behavior.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import timedelta
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Callable, Dict, Optional
+
+import torch
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.environ import envs
+from sglang.srt.managers.io_struct import AbortReq
+from sglang.srt.runtime_context import get_schedule, get_serving
+from sglang.srt.utils.weight_versions import compute_weight_version_spans
+from sglang.utils import get_exception_traceback
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.managers.scheduler import Scheduler
+
+logger = logging.getLogger(__name__)
+
+# Message substrings that indicate the CUDA/HIP context or the communication
+# layer is likely poisoned. Recovering in-place after one of these would risk
+# hangs or silent corruption, so they keep the crash behavior.
+_FATAL_ERROR_PATTERNS = (
+    "cuda error",
+    "hip error",
+    "illegal memory access",
+    "device-side assert",
+    "ecc error",
+    "uncorrectable",
+    "unspecified launch failure",
+    "context is destroyed",
+    "nccl",
+    "rccl",
+    "cudnn error",
+    "cublas",
+)
+
+
+def is_recoverable_exception(exc: BaseException) -> bool:
+    """Return True if aborting requests and resetting state can safely handle
+    ``exc``; False if the process must crash (existing behavior)."""
+    if not isinstance(exc, Exception):
+        # SystemExit / KeyboardInterrupt / GeneratorExit must propagate.
+        return False
+    if isinstance(exc, MemoryError):
+        # Host memory exhaustion: the process itself is not trustworthy.
+        return False
+    # A failed device allocation is clean: nothing is corrupted, and the
+    # post-recovery cache flush frees memory. Check before the message
+    # patterns ("CUDA out of memory" is not a context poison).
+    oom_types = tuple(
+        t
+        for t in (
+            getattr(torch, "OutOfMemoryError", None),
+            getattr(torch.cuda, "OutOfMemoryError", None),
+        )
+        if isinstance(t, type)
+    )
+    if oom_types and isinstance(exc, oom_types):
+        return True
+    dist_error = getattr(torch.distributed, "DistBackendError", None)
+    if isinstance(dist_error, type) and isinstance(exc, dist_error):
+        return False
+    accelerator_error = getattr(torch, "AcceleratorError", None)
+    if isinstance(accelerator_error, type) and isinstance(exc, accelerator_error):
+        return False
+    message = str(exc).lower()
+    return not any(pattern in message for pattern in _FATAL_ERROR_PATTERNS)
+
+
+def _internal_error_finish_reason(message: str) -> Dict:
+    return {
+        "type": "abort",
+        "status_code": HTTPStatus.INTERNAL_SERVER_ERROR,
+        "message": message,
+    }
+
+
+def _abort_output_for_req(req: Req, message: str) -> AbortReq:
+    return AbortReq(
+        rid=req.rid,
+        finished_reason=_internal_error_finish_reason(message),
+        weight_versions=compute_weight_version_spans(
+            req.weight_version_events,
+            current_version=get_serving().weight_version,
+            num_output_tokens=len(req.output_ids),
+        ),
+    )
+
+
+# =============================================================================
+# Layer 1: request-admission guard
+# =============================================================================
+
+
+def guard_request_admission(
+    scheduler: Scheduler, handler: Callable, recv_req
+) -> None:
+    """Run one tokenized request through ``handler``; on an unexpected
+    exception, abort only this request instead of crashing the scheduler."""
+    try:
+        handler(recv_req)
+    except Exception as exc:
+        if not is_recoverable_exception(exc):
+            raise
+        rid = getattr(recv_req, "rid", None)
+        if rid is None:
+            raise
+        logger.error(
+            "Unexpected error while admitting request %s; aborting only this "
+            "request: %s",
+            rid,
+            get_exception_traceback(),
+        )
+        try:
+            abort_failed_admission(scheduler, recv_req, exc)
+        except Exception:
+            logger.error(
+                "Failed to abort request %s after an admission error: %s",
+                rid,
+                get_exception_traceback(),
+            )
+            raise exc
+
+
+def filter_failed_materialization(
+    scheduler: Scheduler, recv_reqs: list, materialize: Callable
+) -> list:
+    """Run per-request input materialization (e.g. CUDA-VMM multimodal
+    feature unwrapping), aborting only the requests whose payload cannot be
+    materialized instead of crashing the scheduler."""
+    kept = []
+    for recv_req in recv_reqs:
+        try:
+            materialize(recv_req)
+        except Exception as exc:
+            if not is_recoverable_exception(exc):
+                raise
+            if getattr(recv_req, "rid", None) is None:
+                raise
+            logger.error(
+                "Unexpected error while materializing the inputs of request "
+                "%s; aborting only this request: %s",
+                recv_req.rid,
+                get_exception_traceback(),
+            )
+            abort_failed_admission(scheduler, recv_req, exc)
+            continue
+        kept.append(recv_req)
+    return kept
+
+
+def abort_failed_admission(scheduler: Scheduler, recv_req, exc: Exception) -> None:
+    """Return an internal error to the client of a request whose admission
+    raised, and clean up any partially-admitted state for it."""
+    rid = recv_req.rid
+    message = (
+        f"Unexpected internal error while admitting request {rid}: "
+        f"{type(exc).__name__}: {exc}. The request was rejected; other "
+        "requests are unaffected."
+    )
+    # Finish the client-side state first so the client gets the real error
+    # message; a later abort echo for the same rid is ignored harmlessly.
+    scheduler.ipc_channels.send_to_tokenizer.send_output(
+        AbortReq(rid=rid, finished_reason=_internal_error_finish_reason(message)),
+        recv_req,
+    )
+    if _find_partially_admitted(scheduler, rid):
+        # The exception hit after the request reached a queue. Reuse the
+        # standard abort machinery, which knows how to remove a request from
+        # every queue (waiting/grammar/disaggregation) and release resources.
+        scheduler.abort_request(AbortReq(rid=rid))
+
+
+def _find_partially_admitted(scheduler: Scheduler, rid: str) -> bool:
+    for req in scheduler.waiting_queue:
+        if req.rid == rid:
+            return True
+    for req in scheduler.grammar_manager.grammar_queue:
+        if req.rid == rid:
+            return True
+    if scheduler.disaggregation_mode == DisaggregationMode.PREFILL:
+        for req in scheduler.disagg_prefill_bootstrap_queue.queue:
+            if req.rid == rid:
+                return True
+    elif scheduler.disaggregation_mode == DisaggregationMode.DECODE:
+        for decode_req in scheduler.disagg_decode_prealloc_queue.queue:
+            if decode_req.req.rid == rid:
+                return True
+    return False
+
+
+# =============================================================================
+# Layer 2: event-loop recovery
+# =============================================================================
+
+
+def run_event_loop_with_recovery(
+    scheduler: Scheduler, dispatch: Callable[[], None]
+) -> None:
+    """Run the event loop; when enabled, recover in place from recoverable
+    exceptions instead of letting them kill the scheduler process."""
+    if not get_schedule().enable_scheduler_recovery:
+        dispatch()
+        return
+    while True:
+        try:
+            dispatch()
+            return  # Graceful exit (ShutdownReq set gracefully_exit).
+        except Exception as exc:
+            if not try_recover_from_loop_crash(scheduler, exc):
+                raise
+
+
+def try_recover_from_loop_crash(scheduler: Scheduler, exc: Exception) -> bool:
+    """Attempt in-place recovery. Returns True when the scheduler is safe to
+    keep serving; False re-raises the original exception (process crash)."""
+    logger.error(
+        "Scheduler event loop hit an exception; attempting in-place "
+        "recovery: %s",
+        get_exception_traceback(),
+    )
+    if not is_recoverable_exception(exc):
+        logger.error(
+            "The exception is classified as non-recoverable (process or "
+            "device state may be corrupted); crashing the server."
+        )
+        return False
+    if not _recovery_supported(scheduler):
+        return False
+    timeout_s = envs.SGLANG_SCHEDULER_RECOVERY_TIMEOUT.get()
+    if not _consensus_barrier(timeout_s):
+        return False
+    try:
+        num_aborted = _abort_all_inflight_requests(scheduler, exc)
+        _reset_scheduler_state(scheduler, timeout_s)
+    except Exception:
+        logger.error(
+            "In-place recovery failed; crashing the server: %s",
+            get_exception_traceback(),
+        )
+        return False
+    logger.error(
+        "Scheduler recovered in place from an unexpected exception. "
+        "%d in-flight request(s) were aborted with an internal error "
+        "response; the KV cache was reset and serving resumed. "
+        "Root cause: %r",
+        num_aborted,
+        exc,
+    )
+    return True
+
+
+def _recovery_supported(scheduler: Scheduler) -> bool:
+    if scheduler.disaggregation_mode != DisaggregationMode.NULL:
+        # PD queues can hold requests with in-flight remote KV transfers
+        # (e.g. RDMA writes) that a local reset cannot fence. Keep the crash
+        # behavior there; per-request KV transfer failures are already
+        # handled by the disaggregation queues themselves.
+        logger.error(
+            "In-place recovery is not supported in disaggregation mode; "
+            "crashing the server."
+        )
+        return False
+    if scheduler.ps.pp_size > 1:
+        logger.error(
+            "In-place recovery is not supported with pipeline parallelism; "
+            "crashing the server."
+        )
+        return False
+    if scheduler.enable_pdmux:
+        logger.error(
+            "In-place recovery is not supported with PD multiplexing; "
+            "crashing the server."
+        )
+        return False
+    return True
+
+
+def _consensus_barrier(timeout_s: float) -> bool:
+    """Make sure every rank of this scheduler's distributed world is also in
+    recovery before any rank resets its state.
+
+    A deterministic, request-driven exception raises on all ranks at the same
+    loop iteration (request intake is broadcast from attn-TP rank 0), so all
+    ranks arrive here and recover consistently. If any rank did NOT fail --
+    e.g. a rank-local error while peers wait inside a collective -- the
+    barrier times out and the crash behavior is kept, because a one-sided
+    reset would desynchronize the ranks. The hard watchdog remains the
+    backstop for any divergence that slips through.
+    """
+    try:
+        if not torch.distributed.is_initialized():
+            return True
+        from sglang.srt.distributed import get_world_group
+
+        world_group = get_world_group()
+        if world_group.world_size <= 1:
+            return True
+        cpu_group = world_group.cpu_group
+    except Exception:
+        logger.error(
+            "Could not determine the distributed topology for recovery "
+            "consensus; crashing the server: %s",
+            get_exception_traceback(),
+        )
+        return False
+    try:
+        torch.distributed.monitored_barrier(
+            group=cpu_group, timeout=timedelta(seconds=timeout_s)
+        )
+        return True
+    except Exception:
+        logger.error(
+            "Recovery consensus barrier failed (some ranks did not reach "
+            "recovery within %.1fs); crashing the server: %s",
+            timeout_s,
+            get_exception_traceback(),
+        )
+        return False
+
+
+def _collect_inflight_requests(scheduler: Scheduler) -> Dict[str, Req]:
+    """All not-yet-finished requests the scheduler currently owns, deduped by
+    rid. Their KV and pool resources are reclaimed wholesale by the cache
+    flush, so no per-request release is attempted here."""
+    reqs: Dict[str, Req] = {}
+
+    def add(req: Optional[Req]) -> None:
+        if req is None or req.finished():
+            return
+        reqs.setdefault(req.rid, req)
+
+    add(scheduler.chunked_req)
+    for batch in (scheduler.cur_batch_for_debug, scheduler.last_batch):
+        if batch is not None:
+            for req in batch.reqs:
+                add(req)
+    for req in scheduler.collect_inflight_reqs():
+        add(req)
+    if getattr(scheduler, "result_queue", None) is not None:
+        for batch, _ in scheduler.result_queue:
+            for req in batch.reqs:
+                add(req)
+    for req in scheduler.waiting_queue:
+        add(req)
+    for req in scheduler.grammar_manager.grammar_queue:
+        add(req)
+    if scheduler.dllm_manager is not None:
+        for req in scheduler.dllm_manager.pop_aborted_reqs(True, ""):
+            add(req)
+    return reqs
+
+
+def _abort_all_inflight_requests(scheduler: Scheduler, exc: Exception) -> int:
+    message = (
+        "The server recovered from an unexpected internal error while this "
+        "request was in flight. The request was aborted; please retry. "
+        f"Root cause: {type(exc).__name__}: {exc}"
+    )
+    reqs = _collect_inflight_requests(scheduler)
+    for req in reqs.values():
+        # Notification is best-effort per request: one bad request object
+        # must not block the recovery of the server.
+        try:
+            scheduler.ipc_channels.send_to_tokenizer.send_output(
+                _abort_output_for_req(req, message), req
+            )
+        except Exception:
+            logger.error(
+                "Failed to notify the client of aborted request %s: %s",
+                req.rid,
+                get_exception_traceback(),
+            )
+        try:
+            scheduler.beam_coordinator.retire_group(req)
+        except Exception:
+            pass
+        if scheduler.enable_hicache_storage:
+            try:
+                scheduler.tree_cache.release_aborted_request(req.rid)
+            except Exception:
+                pass
+    if scheduler.mm_receiver is not None:
+        # EPD: requests parked while waiting for encoder embeddings.
+        scheduler.mm_receiver.abort_waiting_requests(AbortReq(abort_all=True))
+    return len(reqs)
+
+
+def _reset_scheduler_state(scheduler: Scheduler, timeout_s: float) -> None:
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
+
+    # Drop every scheduling structure without touching per-request KV
+    # bookkeeping; the cache flush below rebuilds the pools from scratch.
+    scheduler.waiting_queue.clear()
+    for req in scheduler.grammar_manager.grammar_queue:
+        grammar = req.grammar
+        if grammar is not None and hasattr(grammar, "cancel"):
+            try:
+                grammar.cancel()
+            except Exception:
+                pass
+    scheduler.grammar_manager.grammar_queue.clear()
+    scheduler.chunked_req = None
+    scheduler._pending_chunked_abort_req = None
+    scheduler.running_batch = ScheduleBatch(reqs=[], batch_is_full=False)
+    scheduler.last_batch = None
+    scheduler.cur_batch_for_debug = None
+    if getattr(scheduler, "result_queue", None) is not None:
+        scheduler.result_queue.clear()
+
+    # Wait for already-launched device work (forward/sampling streams) to
+    # drain before resetting the pools it reads and writes.
+    try:
+        scheduler.device_module.synchronize()
+    except Exception:
+        logger.warning(
+            "Device synchronize during recovery failed: %s",
+            get_exception_traceback(),
+        )
+
+    # Asynchronous subsystems (e.g. HiCache host offload) must finish before
+    # a destructive reset. If they cannot drain in time, give up and crash.
+    deadline = time.monotonic() + timeout_s
+    while not scheduler.is_fully_idle():
+        if time.monotonic() > deadline:
+            raise RuntimeError(
+                "The scheduler still has in-flight background work after "
+                f"aborting all requests (waited {timeout_s:.1f}s); "
+                "a safe in-place reset is not possible."
+            )
+        time.sleep(0.01)
+
+    if not scheduler.flush_cache():
+        raise RuntimeError("Cache flush failed during scheduler recovery.")

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -911,6 +911,11 @@ class ServerArgs:
         ),
         NS("schedule"),
     ] = False
+    enable_scheduler_recovery: A[
+        bool,
+        "When the scheduler hits an unexpected exception, abort all in-flight requests with an internal error response, reset the KV cache and scheduling state, and keep serving instead of crashing the whole server. Errors that indicate a corrupted process (e.g. CUDA context poison, communicator failures) still crash the server. Not supported with disaggregation, pipeline parallelism, or PD multiplexing.",
+        NS("schedule"),
+    ] = False
     num_continuous_decode_steps: A[
         int,
         "Run multiple continuous decoding steps to reduce scheduling overhead. This can potentially increase throughput but may also increase time-to-first-token latency. The default value is 1, meaning only run one decoding step at a time.",

--- a/test/registered/scheduler/test_scheduler_recovery.py
+++ b/test/registered/scheduler/test_scheduler_recovery.py
@@ -1,0 +1,91 @@
+"""E2E: with --enable-scheduler-recovery, an unexpected exception in the
+scheduler's forward path fails only the affected request with HTTP 500 and
+the server keeps serving.
+
+The failure is injected with SGLANG_TEST_SCHEDULER_RECOVERY_CRASH:
+Scheduler.run_batch raises for any batch containing a request whose rid
+carries TEST_RECOVERY_CRASH_RID_MARKER, which exercises the full recovery
+path (abort every in-flight request with an internal error response, reset
+the KV cache and scheduling state, resume the event loop). The bookkeeping
+details of recovery are covered by
+unit/managers/scheduler_components/test_error_isolation.py.
+"""
+
+import unittest
+import uuid
+
+import requests
+
+from sglang.srt.environ import envs
+from sglang.srt.managers.scheduler_components.error_isolation import (
+    TEST_RECOVERY_CRASH_RID_MARKER,
+)
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=120, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestSchedulerRecovery(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        with envs.SGLANG_TEST_SCHEDULER_RECOVERY_CRASH.override(True):
+            cls.process = popen_launch_server(
+                cls.model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=["--enable-scheduler-recovery"],
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def _generate(self, rid=None):
+        payload = {
+            "text": "The capital of France is",
+            "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+        }
+        if rid is not None:
+            payload["rid"] = rid
+        return requests.post(f"{self.base_url}/generate", json=payload, timeout=120)
+
+    def _assert_healthy_generation(self):
+        resp = self._generate()
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("text", resp.json())
+
+    def test_a_crashing_request_gets_500_and_the_server_keeps_serving(self):
+        self._assert_healthy_generation()
+
+        # Recovery must work repeatedly, not just once per process.
+        for round_idx in range(2):
+            # The poisoned request crashes the scheduler event loop; recovery
+            # turns that into an internal error response for it alone.
+            rid = f"{TEST_RECOVERY_CRASH_RID_MARKER}-{uuid.uuid4().hex}"
+            resp = self._generate(rid=rid)
+            self.assertEqual(resp.status_code, 500, f"round {round_idx}")
+            body = resp.json()
+            self.assertEqual(body["object"], "error")
+            self.assertEqual(body["code"], 500)
+            self.assertIn("please retry", body["message"])
+
+            # The server stayed up and keeps serving new requests.
+            self._assert_healthy_generation()
+
+        health = requests.get(f"{self.base_url}/health", timeout=10)
+        self.assertEqual(health.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/unit/managers/scheduler_components/test_error_isolation.py
+++ b/test/registered/unit/managers/scheduler_components/test_error_isolation.py
@@ -1,0 +1,383 @@
+"""Unit tests for the scheduler's per-request error isolation and in-place
+event-loop recovery (scheduler_components/error_isolation.py).
+
+Every path here is CPU-only bookkeeping over fake scheduler state -- no model,
+no GPU, no distributed init (the recovery consensus barrier short-circuits
+when torch.distributed is not initialized). The e2e side (an injected crash
+returns HTTP 500 for the affected request while the server keeps serving) is
+covered by scheduler/test_scheduler_recovery.py.
+"""
+
+import unittest
+from collections import deque
+from http import HTTPStatus
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+import torch
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.environ import envs
+from sglang.srt.managers.io_struct import AbortReq
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.scheduler_components import error_isolation
+from sglang.srt.managers.scheduler_components.error_isolation import (
+    filter_failed_materialization,
+    guard_request_admission,
+    is_recoverable_exception,
+    run_event_loop_with_recovery,
+    try_recover_from_loop_crash,
+)
+from sglang.srt.runtime_context import get_context
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+
+class _FakeReq:
+    """Must stay hashable: collect_inflight_reqs builds a set of requests."""
+
+    def __init__(self, rid, *, finished=False, grammar=None):
+        self.rid = rid
+        self.output_ids = []
+        self.weight_version_events = []
+        self.grammar = grammar
+        self._finished = finished
+
+    def finished(self):
+        return self._finished
+
+
+def _admission_scheduler():
+    s = Scheduler.__new__(Scheduler)
+    s.ipc_channels = SimpleNamespace(send_to_tokenizer=MagicMock())
+    s.waiting_queue = []
+    s.grammar_manager = SimpleNamespace(grammar_queue=[])
+    s.disaggregation_mode = DisaggregationMode.NULL
+    s.abort_request = MagicMock()
+    return s
+
+
+def _recovery_scheduler(**overrides):
+    """A scheduler with every structure the recovery path touches, all empty
+    or idle by default. collect_inflight_reqs is the real method."""
+    s = Scheduler.__new__(Scheduler)
+    s.disaggregation_mode = DisaggregationMode.NULL
+    s.ps = SimpleNamespace(pp_size=1)
+    s.enable_pdmux = False
+    s.enable_hicache_storage = False
+    s.mm_receiver = None
+    s.dllm_manager = None
+    s.chunked_req = None
+    s._pending_chunked_abort_req = None
+    s.running_batch = SimpleNamespace(reqs=[])
+    s.last_batch = None
+    s.cur_batch_for_debug = None
+    s.result_queue = deque()
+    s.waiting_queue = []
+    s.grammar_manager = SimpleNamespace(grammar_queue=[])
+    s.ipc_channels = SimpleNamespace(send_to_tokenizer=MagicMock())
+    s.beam_coordinator = MagicMock()
+    s.device_module = MagicMock()
+    s.is_fully_idle = MagicMock(return_value=True)
+    s.flush_cache = MagicMock(return_value=True)
+    for name, value in overrides.items():
+        setattr(s, name, value)
+    return s
+
+
+def _sent_aborts(scheduler):
+    return [
+        call.args[0]
+        for call in scheduler.ipc_channels.send_to_tokenizer.send_output.call_args_list
+    ]
+
+
+class TestExceptionClassification(CustomTestCase):
+    def test_ordinary_request_driven_exceptions_are_recoverable(self):
+        for exc in (
+            RuntimeError("shape mismatch between embeddings and input_ids"),
+            ValueError("invalid multimodal payload"),
+            KeyError("missing_session"),
+            AssertionError("batch invariant violated"),
+            IndexError("list index out of range"),
+        ):
+            self.assertTrue(is_recoverable_exception(exc), repr(exc))
+
+    def test_process_level_failures_are_not_recoverable(self):
+        self.assertFalse(is_recoverable_exception(MemoryError()))
+        self.assertFalse(is_recoverable_exception(SystemExit(0)))
+        self.assertFalse(is_recoverable_exception(KeyboardInterrupt()))
+
+    def test_device_oom_is_recoverable(self):
+        # A failed allocation is clean, and the recovery flush frees memory.
+        oom_type = getattr(torch, "OutOfMemoryError", None) or getattr(
+            torch.cuda, "OutOfMemoryError"
+        )
+        oom = oom_type("CUDA out of memory. Tried to allocate 20.00 GiB")
+        self.assertTrue(is_recoverable_exception(oom))
+
+    def test_poisoned_device_or_comm_errors_are_not_recoverable(self):
+        for message in (
+            "CUDA error: an illegal memory access was encountered",
+            "CUDA error: device-side assert triggered",
+            "CUDA error: unspecified launch failure",
+            "NCCL communicator was aborted on rank 1",
+            "cuBLAS error: CUBLAS_STATUS_EXECUTION_FAILED",
+            "HIP error: uncorrectable ECC error encountered",
+        ):
+            self.assertFalse(is_recoverable_exception(RuntimeError(message)), message)
+
+    def test_dist_backend_error_is_not_recoverable(self):
+        err_type = getattr(torch.distributed, "DistBackendError", None)
+        if err_type is None:
+            self.skipTest("this torch build has no DistBackendError")
+        self.assertFalse(is_recoverable_exception(err_type("connection reset")))
+
+    def test_accelerator_error_is_not_recoverable(self):
+        err_type = getattr(torch, "AcceleratorError", None)
+        if err_type is None:
+            self.skipTest("this torch build has no AcceleratorError")
+        self.assertFalse(is_recoverable_exception(err_type("device fault")))
+
+
+class TestAdmissionGuard(CustomTestCase):
+    def test_a_successful_admission_has_no_side_effects(self):
+        s = _admission_scheduler()
+        handler = MagicMock()
+        recv = SimpleNamespace(rid="ok")
+
+        guard_request_admission(s, handler, recv)
+
+        handler.assert_called_once_with(recv)
+        s.ipc_channels.send_to_tokenizer.send_output.assert_not_called()
+        s.abort_request.assert_not_called()
+
+    def test_an_admission_error_aborts_only_that_request(self):
+        s = _admission_scheduler()
+        recv = SimpleNamespace(rid="bad")
+
+        def handler(req):
+            raise ValueError("malformed multimodal payload")
+
+        guard_request_admission(s, handler, recv)  # must not raise
+
+        out, echoed = s.ipc_channels.send_to_tokenizer.send_output.call_args.args
+        self.assertIsInstance(out, AbortReq)
+        self.assertEqual(out.rid, "bad")
+        self.assertEqual(
+            out.finished_reason["status_code"], HTTPStatus.INTERNAL_SERVER_ERROR
+        )
+        self.assertIn("malformed multimodal payload", out.finished_reason["message"])
+        self.assertIs(echoed, recv)
+        # The request never reached a queue, so no queue-side abort is needed.
+        s.abort_request.assert_not_called()
+
+    def test_a_partially_admitted_request_is_cleaned_up(self):
+        s = _admission_scheduler()
+        recv = SimpleNamespace(rid="partial")
+
+        def handler(req):
+            s.waiting_queue.append(_FakeReq("partial"))
+            raise RuntimeError("failure after enqueueing")
+
+        guard_request_admission(s, handler, recv)
+
+        s.abort_request.assert_called_once()
+        self.assertEqual(s.abort_request.call_args.args[0].rid, "partial")
+
+    def test_non_recoverable_errors_keep_the_crash_behavior(self):
+        s = _admission_scheduler()
+
+        def handler(req):
+            raise RuntimeError("CUDA error: device-side assert triggered")
+
+        with self.assertRaisesRegex(RuntimeError, "device-side assert"):
+            guard_request_admission(s, handler, SimpleNamespace(rid="r"))
+        s.ipc_channels.send_to_tokenizer.send_output.assert_not_called()
+
+    def test_requests_without_a_rid_keep_the_crash_behavior(self):
+        s = _admission_scheduler()
+
+        def handler(req):
+            raise ValueError("boom")
+
+        with self.assertRaisesRegex(ValueError, "boom"):
+            guard_request_admission(s, handler, SimpleNamespace())
+
+    def test_a_failing_abort_reraises_the_admission_error(self):
+        s = _admission_scheduler()
+        s.ipc_channels.send_to_tokenizer.send_output.side_effect = RuntimeError(
+            "ipc channel down"
+        )
+
+        def handler(req):
+            raise ValueError("original admission bug")
+
+        with self.assertRaisesRegex(ValueError, "original admission bug"):
+            guard_request_admission(s, handler, SimpleNamespace(rid="r"))
+
+
+class TestFilterFailedMaterialization(CustomTestCase):
+    def test_only_the_failing_request_is_dropped(self):
+        s = _admission_scheduler()
+        r1, r2, r3 = (SimpleNamespace(rid=f"r{i}") for i in (1, 2, 3))
+
+        def materialize(req):
+            if req is r2:
+                raise ValueError("bad multimodal feature handle")
+
+        kept = filter_failed_materialization(s, [r1, r2, r3], materialize)
+
+        self.assertEqual(kept, [r1, r3])
+        self.assertEqual([out.rid for out in _sent_aborts(s)], ["r2"])
+
+    def test_non_recoverable_errors_propagate(self):
+        s = _admission_scheduler()
+
+        def materialize(req):
+            raise RuntimeError("NCCL error: unhandled system error")
+
+        with self.assertRaisesRegex(RuntimeError, "NCCL"):
+            filter_failed_materialization(s, [SimpleNamespace(rid="r1")], materialize)
+
+
+class TestRunEventLoopWithRecovery(CustomTestCase):
+    def _publish(self, enabled: bool):
+        override = get_context().override_server_args(enable_scheduler_recovery=enabled)
+        override.install()
+        self.addCleanup(override.restore)
+
+    def test_disabled_recovery_keeps_the_crash_behavior(self):
+        self._publish(False)
+        dispatch = MagicMock(side_effect=RuntimeError("loop bug"))
+
+        with self.assertRaisesRegex(RuntimeError, "loop bug"):
+            run_event_loop_with_recovery(MagicMock(), dispatch)
+        dispatch.assert_called_once()
+
+    def test_enabled_recovery_resumes_the_loop(self):
+        self._publish(True)
+        dispatch = MagicMock(side_effect=[RuntimeError("loop bug"), None])
+
+        with patch.object(
+            error_isolation, "try_recover_from_loop_crash", return_value=True
+        ) as recover:
+            run_event_loop_with_recovery(MagicMock(), dispatch)
+
+        self.assertEqual(dispatch.call_count, 2)
+        recover.assert_called_once()
+
+    def test_failed_recovery_reraises_the_loop_error(self):
+        self._publish(True)
+        dispatch = MagicMock(side_effect=RuntimeError("loop bug"))
+
+        with patch.object(
+            error_isolation, "try_recover_from_loop_crash", return_value=False
+        ):
+            with self.assertRaisesRegex(RuntimeError, "loop bug"):
+                run_event_loop_with_recovery(MagicMock(), dispatch)
+        dispatch.assert_called_once()
+
+
+class TestLoopCrashRecovery(CustomTestCase):
+    def setUp(self):
+        # _abort_output_for_req reads the serving weight version off the bag.
+        override = get_context().override_server_args()
+        override.install()
+        self.addCleanup(override.restore)
+
+    def test_recovery_aborts_all_inflight_requests_and_resets_state(self):
+        running = _FakeReq("running")
+        waiting = _FakeReq("waiting")
+        finished = _FakeReq("finished", finished=True)
+        chunked = _FakeReq("chunked")
+        grammar_req = _FakeReq("grammar", grammar=MagicMock())
+        queued = _FakeReq("queued")
+        s = _recovery_scheduler(
+            chunked_req=chunked,
+            # `running` appears in three places and must be aborted once.
+            running_batch=SimpleNamespace(reqs=[running]),
+            last_batch=SimpleNamespace(reqs=[running]),
+            cur_batch_for_debug=SimpleNamespace(reqs=[running]),
+            result_queue=deque([(SimpleNamespace(reqs=[queued]), None)]),
+            waiting_queue=[waiting, finished],
+            grammar_manager=SimpleNamespace(grammar_queue=[grammar_req]),
+        )
+
+        ok = try_recover_from_loop_crash(s, RuntimeError("model forward bug"))
+
+        self.assertTrue(ok)
+        outs = _sent_aborts(s)
+        self.assertEqual(len(outs), 5, "one abort per unfinished unique request")
+        self.assertEqual(
+            {out.rid for out in outs},
+            {"running", "waiting", "chunked", "grammar", "queued"},
+        )
+        for out in outs:
+            self.assertEqual(
+                out.finished_reason["status_code"], HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+            self.assertIn("model forward bug", out.finished_reason["message"])
+            self.assertTrue(out.weight_versions)
+
+        self.assertEqual(s.waiting_queue, [])
+        self.assertEqual(list(s.grammar_manager.grammar_queue), [])
+        grammar_req.grammar.cancel.assert_called_once()
+        self.assertIsNone(s.chunked_req)
+        self.assertIsNone(s.last_batch)
+        self.assertIsNone(s.cur_batch_for_debug)
+        self.assertEqual(len(s.result_queue), 0)
+        self.assertTrue(s.running_batch.is_empty())
+        s.device_module.synchronize.assert_called_once()
+        s.flush_cache.assert_called_once()
+
+    def test_non_recoverable_exceptions_keep_the_crash_behavior(self):
+        s = _recovery_scheduler(waiting_queue=[_FakeReq("r")])
+        exc = RuntimeError("CUDA error: an illegal memory access was encountered")
+
+        self.assertFalse(try_recover_from_loop_crash(s, exc))
+        s.ipc_channels.send_to_tokenizer.send_output.assert_not_called()
+        s.flush_cache.assert_not_called()
+
+    def test_unsupported_modes_keep_the_crash_behavior(self):
+        for field, value in (
+            ("disaggregation_mode", DisaggregationMode.PREFILL),
+            ("disaggregation_mode", DisaggregationMode.DECODE),
+            ("ps", SimpleNamespace(pp_size=2)),
+            ("enable_pdmux", True),
+        ):
+            s = _recovery_scheduler(**{field: value})
+            self.assertFalse(
+                try_recover_from_loop_crash(s, RuntimeError("bug")),
+                f"{field}={value} must not be recovered in place",
+            )
+            s.ipc_channels.send_to_tokenizer.send_output.assert_not_called()
+            s.flush_cache.assert_not_called()
+
+    def test_a_failed_cache_flush_keeps_the_crash_behavior(self):
+        s = _recovery_scheduler(flush_cache=MagicMock(return_value=False))
+        self.assertFalse(try_recover_from_loop_crash(s, RuntimeError("bug")))
+
+    def test_undrainable_background_work_keeps_the_crash_behavior(self):
+        s = _recovery_scheduler(is_fully_idle=MagicMock(return_value=False))
+        with envs.SGLANG_SCHEDULER_RECOVERY_TIMEOUT.override(0.05):
+            self.assertFalse(try_recover_from_loop_crash(s, RuntimeError("bug")))
+        s.flush_cache.assert_not_called()
+
+    def test_client_notification_is_best_effort(self):
+        s = _recovery_scheduler(waiting_queue=[_FakeReq("r")])
+        s.ipc_channels.send_to_tokenizer.send_output.side_effect = RuntimeError(
+            "ipc channel down"
+        )
+
+        self.assertTrue(try_recover_from_loop_crash(s, RuntimeError("bug")))
+        s.flush_cache.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Today there are several ways for one bad request to kill the whole SGLang process: an unexpected exception while admitting a tokenized request (e.g. a malformed multimodal payload), an exception escaping the scheduler event loop (e.g. from the model forward path), or an unexpected KV poll state in PD disaggregation (`raise RuntimeError(...)` / `raise ValueError(...)`). For serving deployments the resulting hard crash costs a full restart and weight reload, which hurts uptime far more than the failed request itself. Operators want the failing request to get an error response while the server keeps serving.

This PR adds layered, per-request error isolation with conservative defaults: anything that indicates a corrupted process or device context keeps the existing crash behavior.

## Modifications

New module `python/sglang/srt/managers/scheduler_components/error_isolation.py` with three layers:

1. **Request-admission guard (always on).** `handle_generate_request` / `handle_embedding_request` are wrapped so an unexpected exception while admitting one request aborts only that request with an HTTP 500 (`AbortReq` with an `abort` finish reason carrying `status_code=500`), cleaning up any partially-admitted state via the existing `abort_request` machinery. Admission runs the same deterministic, content-driven code on every TP rank (requests are broadcast from attn-TP rank 0), so a local abort decision is rank-consistent — the same argument that justifies the existing whitelisted `set_finish_with_abort` validation paths. CUDA-VMM multimodal input materialization is guarded per request the same way.

2. **Event-loop recovery (opt-in via `--enable-scheduler-recovery`).** An unexpected exception escaping the scheduler event loop aborts every in-flight request with an internal error response, resets the KV cache and scheduling state (`flush_cache` after a device sync and an idle drain), and resumes serving. Exceptions classified as non-recoverable — host OOM, `DistBackendError`, `AcceleratorError`, and messages indicating CUDA/HIP context poison or NCCL/RCCL failures — still crash the process. Recovery is refused in disaggregation, pipeline-parallel, and PD-multiplexing modes, and a `monitored_barrier` consensus (budget `SGLANG_SCHEDULER_RECOVERY_TIMEOUT`, default 10s) ensures all ranks reached recovery before any rank resets, otherwise the crash behavior is kept.

3. **PD disaggregation poll-state hardening.** Unexpected KV poll states in the prefill bootstrap/inflight queues and the decode prealloc/transfer queues no longer raise process-killing errors; they are normalized to the existing `KVPoll.Failed` handling, which already aborts just the affected request.

Test hook: with `SGLANG_TEST_SCHEDULER_RECOVERY_CRASH` set, `Scheduler.run_batch` raises for any batch containing a request whose rid carries a marker, so tests can poison exactly the requests they choose (health-check and warmup generations are unaffected).

Tests:

- `test/registered/unit/managers/scheduler_components/test_error_isolation.py` (CPU CI): exception classification, admission guard behavior (success, abort-only-this-request, partial-admission cleanup, non-recoverable re-raise, abort-failure re-raise), materialization filtering, and event-loop recovery orchestration over a fully populated fake scheduler (abort fan-out with dedup, state reset, unsupported modes, flush failure, undrainable background work, best-effort notification).
- `test/registered/scheduler/test_scheduler_recovery.py` (1-GPU CI): launches a real server with `--enable-scheduler-recovery` and the crash hook, verifies a poisoned request returns HTTP 500 with an actionable error body while subsequent requests keep succeeding, across repeated crash/recovery rounds.

## Accuracy Tests

Not applicable: no changes to kernels or model forward code. Default behavior is unchanged except that admission errors and unexpected PD poll states now fail only the affected request; event-loop recovery is opt-in.

## Speed Tests and Profiling

No hot-path overhead: the admission guard is a `try/except` around existing per-request handlers, the event-loop wrapper is a no-op unless `--enable-scheduler-recovery` is set, and the `run_batch` test hook short-circuits on a disabled flag.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0534c-a146-79fb-b5f4-98d72c169d02?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0534c-a146-79fb-b5f4-98d72c169d02&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

